### PR TITLE
Add onboarding documentation for .dev.vars

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,4 @@
+ALIGNMENT_FEED_BASE_URL = "https://api.alignmentfeed.org"
+AUTH0_DOMAIN = "alignment-feed.us.auth0.com"
+AUTH0_CLIENT_ID = "aGMS20BZTfNKdXPXAkojqZzPxWqUqbhK"
+AUTH0_DEFAULT_REDIRECT_URI = "https://www.alignmentfeed.org"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 
 ## Development
 
+### Getting Started
+Install your dependences:
+```sh
+npm install
+```
+
+Populate your environment variables:
+```sh
+cp .dev.vars.example .dev.vars
+```
+
 Run the dev server:
 
 ```sh


### PR DESCRIPTION
# What
- Extend README with guidance on how to populate .dev.vars
- Based the contents on the current implementation in `wrangler.toml`

## Future Extension
- A local development version of example .dev.vars should be added that maps onto the default API behavior