### PR TITLE
Appearance Stage A: styled 404, responsive tabs, AA contrast

### DIFF
--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -107,13 +107,13 @@ export function ArticleCard({
       <div className="p-4 flex flex-col flex-grow">
         {/* Date */}
         {article.published_at && (
-          <div className="text-xs text-slate-500 dark:text-slate-500 mb-2">
+          <div className="text-xs text-slate-600 dark:text-slate-300 mb-2">
             {formatPublishedDate(article.published_at)}
           </div>
         )}
 
         {/* Author */}
-        <p className="text-sm text-slate-600 dark:text-slate-400 mb-1 truncate">
+        <p className="text-sm text-slate-600 dark:text-slate-300 mb-1 truncate">
           {article.authors}
         </p>
 

--- a/app/components/article/ArticleCollection.tsx
+++ b/app/components/article/ArticleCollection.tsx
@@ -47,7 +47,7 @@ export function ArticleCollection({
   if (!isLoading && articles.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-4">
-        <p className="text-slate-500 dark:text-slate-400 text-lg">
+        <p className="text-slate-600 dark:text-slate-300 text-lg">
           {emptyMessage}
         </p>
       </div>

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -158,7 +158,7 @@ export function ArticleRow({
                   {article.title}
                 </h3>
               </a>
-              <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+              <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
                 {article.authors}
                 {article.published_at && (
                   <>

--- a/app/components/layout/HeroHeader.tsx
+++ b/app/components/layout/HeroHeader.tsx
@@ -32,7 +32,7 @@ export function HeroHeader({
           onSearch={onSearch}
         />
       )}
-      <div className="flex items-center justify-center gap-4 mt-4 text-xs text-stone-500 dark:text-slate-500">
+      <div className="flex items-center justify-center gap-4 mt-4 text-xs text-stone-600 dark:text-slate-300">
         {rootData?.rssUrl && (
           <a
             href={rootData.rssUrl}

--- a/app/components/layout/SearchBar.tsx
+++ b/app/components/layout/SearchBar.tsx
@@ -60,7 +60,7 @@ export function SearchBar({
         onChange={e => setLocalValue(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full px-6 py-4 pr-14 text-base text-slate-900 dark:text-slate-100 bg-stone-50 dark:bg-slate-800 border border-stone-200 dark:border-slate-600 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 focus:border-transparent placeholder:text-stone-400 dark:placeholder:text-slate-500"
+        className="w-full px-6 py-4 pr-14 text-base text-slate-900 dark:text-slate-100 bg-stone-50 dark:bg-slate-800 border border-stone-200 dark:border-slate-600 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 focus:border-transparent placeholder:text-stone-500 dark:placeholder:text-slate-400"
         aria-label="Search articles"
       />
       <button

--- a/app/components/layout/ViewToggle.tsx
+++ b/app/components/layout/ViewToggle.tsx
@@ -9,7 +9,7 @@ interface ViewToggleProps {
 
 export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
   return (
-    <div className="flex items-center gap-1 rounded-md border border-stone-200 dark:border-slate-700 p-0.5">
+    <div className="flex flex-shrink-0 items-center gap-1 rounded-md border border-stone-200 dark:border-slate-700 p-0.5">
       <button
         type="button"
         onClick={() => onChange("list")}

--- a/app/components/ui/Tabs.tsx
+++ b/app/components/ui/Tabs.tsx
@@ -16,14 +16,14 @@ interface TabsProps {
 
 export function Tabs({ tabs, activeTab, onBeforeNavigate }: TabsProps) {
   return (
-    <nav className="flex gap-6 border-b border-stone-300 dark:border-slate-700">
+    <nav className="flex gap-6 overflow-x-auto min-w-0 border-b border-stone-300 dark:border-slate-700 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       {tabs.map(tab => {
         const isActive = activeTab === tab.id;
 
-        const baseClassName = `pb-3 text-sm font-medium transition-colors relative ${
+        const baseClassName = `pb-3 text-sm font-medium transition-colors relative whitespace-nowrap flex-shrink-0 ${
           isActive
             ? "text-slate-900 dark:text-slate-100"
-            : "text-stone-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+            : "text-stone-600 dark:text-slate-300 hover:text-slate-700 dark:hover:text-slate-200"
         }`;
 
         return (

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -163,35 +163,28 @@ export function ErrorBoundary() {
     }
   }
 
+  // Return only the inner content: the exported `Layout` wraps this with
+  // <html>/<head>/<Links> (tailwind.css) and the themed <body>, so the error
+  // page is styled and dark-mode correct instead of bare browser defaults.
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>{`${title} - Alignment Feed`}</title>
-        <Meta />
-        <Links />
-      </head>
-      <body className="bg-stone-100 dark:bg-slate-800 min-h-screen flex items-center justify-center">
-        <div className="max-w-md mx-auto px-6 py-12 text-center">
-          {statusCode && (
-            <p className="text-6xl font-bold text-stone-300 dark:text-slate-600 mb-4">
-              {statusCode}
-            </p>
-          )}
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
-            {title}
-          </h1>
-          <p className="text-slate-600 dark:text-slate-400 mb-8">{message}</p>
-          <Link
-            to="/"
-            className="inline-block px-6 py-3 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-lg font-medium hover:opacity-90 transition-opacity"
-          >
-            Back to Home
-          </Link>
-        </div>
-        <Scripts />
-      </body>
-    </html>
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="max-w-md mx-auto px-6 py-12 text-center">
+        {statusCode && (
+          <p className="text-6xl font-bold text-stone-300 dark:text-slate-600 mb-4">
+            {statusCode}
+          </p>
+        )}
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+          {title}
+        </h1>
+        <p className="text-slate-600 dark:text-slate-400 mb-8">{message}</p>
+        <Link
+          to="/"
+          className="inline-block px-6 py-3 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-lg font-medium hover:opacity-90 transition-opacity"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -201,7 +201,7 @@ export default function Index() {
 
               {/* End of results indicator */}
               {!hasMore && articles.length > 0 && (
-                <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+                <div className="text-center py-8 text-slate-600 dark:text-slate-300">
                   You&apos;ve reached the end of the results.
                 </div>
               )}

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -145,7 +145,7 @@ export default function ArticleDetails() {
 
               {article.key_points && article.key_points.length > 0 && (
                 <div className="mb-4">
-                  <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">
+                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                     Key Points
                   </h3>
                   <ul className="list-disc list-inside space-y-1 text-slate-700 dark:text-slate-300">
@@ -158,7 +158,7 @@ export default function ArticleDetails() {
 
               {article.implication && (
                 <div>
-                  <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">
+                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                     Implications for AI Alignment
                   </h3>
                   <p className="text-slate-700 dark:text-slate-300">

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -67,8 +67,10 @@ export default function Chat() {
         <HeroHeader showSearch={false} />
 
         {/* Tabs */}
-        <div className="max-w-7xl mx-auto px-6 pt-8">
-          <Tabs tabs={MAIN_TABS} activeTab="chat" />
+        <div className="max-w-7xl w-full mx-auto px-6 pt-8">
+          <div className="flex items-center">
+            <Tabs tabs={MAIN_TABS} activeTab="chat" />
+          </div>
         </div>
 
         {/* Content */}

--- a/app/routes/disliked.tsx
+++ b/app/routes/disliked.tsx
@@ -119,7 +119,7 @@ export default function Disliked() {
               )}
 
               {!hasMore && articles.length > 0 && (
-                <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+                <div className="text-center py-8 text-slate-600 dark:text-slate-300">
                   You&apos;ve reached the end of the results.
                 </div>
               )}

--- a/app/routes/liked.tsx
+++ b/app/routes/liked.tsx
@@ -119,7 +119,7 @@ export default function Liked() {
               )}
 
               {!hasMore && articles.length > 0 && (
-                <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+                <div className="text-center py-8 text-slate-600 dark:text-slate-300">
                   You&apos;ve reached the end of the results.
                 </div>
               )}

--- a/app/routes/semantic-search.tsx
+++ b/app/routes/semantic-search.tsx
@@ -111,7 +111,7 @@ export default function SemanticSearch() {
               onChange={e => setText(e.target.value)}
               placeholder="Paste a snippet, abstract, or topic description to find related research..."
               rows={4}
-              className="w-full rounded-md border border-stone-300 dark:border-slate-600 bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light px-4 py-3 text-sm placeholder:text-stone-400 dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 resize-y"
+              className="w-full rounded-md border border-stone-300 dark:border-slate-600 bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light px-4 py-3 text-sm placeholder:text-stone-500 dark:placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 resize-y"
             />
             <Button
               variant="primary"

--- a/app/routes/unreviewed.tsx
+++ b/app/routes/unreviewed.tsx
@@ -122,7 +122,7 @@ export default function Unreviewed() {
               )}
 
               {!hasMore && articles.length > 0 && (
-                <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+                <div className="text-center py-8 text-slate-600 dark:text-slate-300">
                   You&apos;ve reached the end of the results.
                 </div>
               )}


### PR DESCRIPTION
## Appearance Stage A — three critical fixes

First of a staged appearance pass derived from a multi-lens visual review of `main`. Scope here is the three **critical** findings; later stages (colour/dark polish, designed non-data states, type & icons, layout/system) follow as separate PRs.

### What changed
- **QW-1 · Styled global 404 / error page.** The root `ErrorBoundary` in `app/root.tsx` rendered its own bare `<html>`, bypassing the app stylesheet — it showed unstyled browser defaults and was **pixel-identical white in dark mode**. Refactored it to return only the inner content so the exported `Layout` wraps it (stylesheet + themed body + dark mode); keeps the teal "Back to Home" action.
- **QW-2 · Responsive primary tabs.** The 7-item nav never wrapped/scrolled, forcing the page to ~605px wide at a 360px viewport (chat ~563px) and wrapping to double height at 768px. Tab strip is now a hidden-scrollbar horizontal scroller (`overflow-x-auto`, per-tab `whitespace-nowrap`), `ViewToggle` stays put, and the chat page's tab wrapper (a real second overflow source — a shrink-to-content flex item in a `flex-col` page) is fixed with `w-full`.
- **QW-3 · Muted supporting text → WCAG AA.** Colour-token-only darkening of card date/author, inactive tab labels, detail overlines, feed footers, hero utility links, search placeholders, and the empty-state — in both light and dark. Decorative/disabled/interactive tokens left untouched.

### Verification
- Repo gate green: `format:check`, `lint`, `typecheck`, **`vitest` 196/196**, `build` (no test changes needed — nothing asserted on the changed classes).
- In-browser render check (offline, both schemes), 7/7 PASS: 404 dark body `rgb(30,41,59)` (dark surface, not white) + teal action; feed and chat `scrollWidth=360` at 360px; tab nav single-row (33px) at 768px.

15 files changed, +43/−48 — tokens/markup only, no behavioural or structural refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
