### PR TITLE
Appearance Stage B: restrained dark accent, CVD feedback cue, halation

### DIFF
--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -131,8 +131,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsUp}
             disabled={isUpdating}
-            className={`flex items-center gap-1 hover:text-green-600 dark:hover:text-green-400 transition-colors ${
-              thumbsUp ? "text-green-600 dark:text-green-400" : ""
+            className={`flex items-center gap-1 rounded-full px-2 py-1 transition-colors ${
+              thumbsUp
+                ? "text-green-600 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/50 dark:ring-green-400/50"
+                : "hover:text-green-600 dark:hover:text-green-400"
             }`}
             aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
           >
@@ -146,8 +148,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsDown}
             disabled={isUpdating}
-            className={`flex items-center gap-1 hover:text-red-600 dark:hover:text-red-400 transition-colors ${
-              thumbsDown ? "text-red-600 dark:text-red-400" : ""
+            className={`flex items-center gap-1 rounded-full px-2 py-1 transition-colors ${
+              thumbsDown
+                ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/50 dark:ring-red-400/50"
+                : "hover:text-red-600 dark:hover:text-red-400"
             }`}
             aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
           >

--- a/app/components/article/ArticleCollection.tsx
+++ b/app/components/article/ArticleCollection.tsx
@@ -47,7 +47,7 @@ export function ArticleCollection({
   if (!isLoading && articles.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-4">
-        <p className="text-slate-600 dark:text-slate-300 text-lg">
+        <p className="text-slate-600 dark:text-accent-dark-fg text-lg">
           {emptyMessage}
         </p>
       </div>

--- a/app/components/article/ArticleInfo.tsx
+++ b/app/components/article/ArticleInfo.tsx
@@ -94,7 +94,7 @@ export function ArticleInfo({
             href={article.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-5 py-2.5 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-lg font-medium hover:bg-accent-hover dark:hover:bg-teal-300 transition-colors"
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-accent dark:bg-accent-dark text-white rounded-lg font-medium hover:bg-accent-hover dark:hover:bg-accent-dark-hover transition-colors"
           >
             Read Article
             <ExternalLinkIcon className="w-4 h-4" />

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -193,10 +193,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsUp}
           disabled={isUpdating}
-          className={`flex items-center gap-1 px-2 py-1 rounded text-sm hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors ${
+          className={`flex items-center gap-1 px-2 py-1 rounded-full text-sm transition-colors ${
             thumbsUp
-              ? "text-green-600 dark:text-green-400"
-              : "text-slate-500 dark:text-slate-400"
+              ? "text-green-600 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/50 dark:ring-green-400/50"
+              : "text-slate-500 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
           aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
         >
@@ -210,10 +210,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsDown}
           disabled={isUpdating}
-          className={`flex items-center gap-1 px-2 py-1 rounded text-sm hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors ${
+          className={`flex items-center gap-1 px-2 py-1 rounded-full text-sm transition-colors ${
             thumbsDown
-              ? "text-red-600 dark:text-red-400"
-              : "text-slate-500 dark:text-slate-400"
+              ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/50 dark:ring-red-400/50"
+              : "text-slate-500 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
           aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
         >
@@ -234,7 +234,7 @@ export function ArticleRow({
             onClick={() => handleSectionToggle("summary")}
             className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
               expandedSection === "summary"
-                ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+                ? "bg-accent text-white dark:bg-accent-dark"
                 : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
@@ -247,7 +247,7 @@ export function ArticleRow({
             onClick={() => handleSectionToggle("key_points")}
             className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
               expandedSection === "key_points"
-                ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+                ? "bg-accent text-white dark:bg-accent-dark"
                 : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
@@ -260,7 +260,7 @@ export function ArticleRow({
             onClick={() => handleSectionToggle("implication")}
             className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
               expandedSection === "implication"
-                ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+                ? "bg-accent text-white dark:bg-accent-dark"
                 : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
@@ -272,7 +272,7 @@ export function ArticleRow({
           onClick={() => handleSectionToggle("similar")}
           className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
             expandedSection === "similar"
-              ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+              ? "bg-accent text-white dark:bg-accent-dark"
               : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
         >

--- a/app/components/chat/ChatArticleCard.tsx
+++ b/app/components/chat/ChatArticleCard.tsx
@@ -17,7 +17,7 @@ export function ChatArticleCard({
       onClick={
         onArticleClick ? () => onArticleClick(article.hash_id) : undefined
       }
-      className="block rounded-lg border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-slate-700 p-3 hover:border-accent dark:hover:border-teal-400 transition-colors"
+      className="block rounded-lg border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-slate-700 p-3 hover:border-accent dark:hover:border-accent-dark-fg transition-colors"
     >
       <h4 className="text-sm font-medium text-slate-900 dark:text-slate-100 line-clamp-2">
         {article.title}

--- a/app/components/chat/ChatInput.tsx
+++ b/app/components/chat/ChatInput.tsx
@@ -68,7 +68,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
           <button
             type="submit"
             disabled={isLoading || !value.trim()}
-            className="rounded-lg bg-accent dark:bg-teal-400 px-4 py-3 text-sm font-medium text-white dark:text-slate-900 hover:bg-accent-hover dark:hover:bg-teal-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="rounded-lg bg-accent dark:bg-accent-dark px-4 py-3 text-sm font-medium text-white hover:bg-accent-hover dark:hover:bg-accent-dark-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {isLoading ? "..." : "Send"}
           </button>

--- a/app/components/chat/ChatMessage.tsx
+++ b/app/components/chat/ChatMessage.tsx
@@ -105,7 +105,7 @@ function ChatMarkdown({
                   ? () => onArticleClick(hashId)
                   : undefined
               }
-              className="text-teal-700 dark:text-teal-400 underline hover:text-teal-900 dark:hover:text-teal-300"
+              className="text-teal-700 dark:text-accent-dark-fg underline hover:text-teal-900 dark:hover:text-accent-dark-fg-hover"
             >
               {children}
             </a>
@@ -330,7 +330,7 @@ export function ChatMessage({
       <div
         className={`max-w-[85%] rounded-lg px-4 py-3 ${
           isUser
-            ? "bg-accent text-white dark:bg-teal-900"
+            ? "bg-accent text-white dark:bg-accent-dark"
             : "bg-stone-50 dark:bg-slate-700 text-slate-900 dark:text-slate-100 border border-stone-200 dark:border-slate-600"
         }`}
       >

--- a/app/components/layout/HeroHeader.tsx
+++ b/app/components/layout/HeroHeader.tsx
@@ -22,7 +22,7 @@ export function HeroHeader({
 
   return (
     <section className="text-center pt-20 pb-8 px-4 bg-brand-bg dark:bg-brand-bg-dark">
-      <h1 className="text-3xl md:text-4xl lg:text-5xl font-light italic text-slate-900 dark:text-slate-100 mb-8 font-serif">
+      <h1 className="text-3xl md:text-4xl lg:text-5xl font-light italic text-slate-900 dark:text-slate-200 mb-8 font-serif">
         Your personalised AI Safety research feed.
       </h1>
       {showSearch && onSearchChange && onSearch && (

--- a/app/components/layout/SearchBar.tsx
+++ b/app/components/layout/SearchBar.tsx
@@ -60,7 +60,7 @@ export function SearchBar({
         onChange={e => setLocalValue(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full px-6 py-4 pr-14 text-base text-slate-900 dark:text-slate-100 bg-stone-50 dark:bg-slate-800 border border-stone-200 dark:border-slate-600 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 focus:border-transparent placeholder:text-stone-500 dark:placeholder:text-slate-400"
+        className="w-full px-6 py-4 pr-14 text-base text-slate-900 dark:text-slate-100 bg-stone-50 dark:bg-slate-800 border border-stone-200 dark:border-slate-600 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-accent-dark-fg focus:border-transparent placeholder:text-stone-500 dark:placeholder:text-slate-400"
         aria-label="Search articles"
       />
       <button

--- a/app/components/layout/ViewToggle.tsx
+++ b/app/components/layout/ViewToggle.tsx
@@ -15,7 +15,7 @@ export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
         onClick={() => onChange("list")}
         className={`rounded p-1.5 transition-colors ${
           viewMode === "list"
-            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-teal-400"
+            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-accent-dark-fg"
             : "text-stone-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
         }`}
         aria-label="List view"
@@ -28,7 +28,7 @@ export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
         onClick={() => onChange("grid")}
         className={`rounded p-1.5 transition-colors ${
           viewMode === "grid"
-            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-teal-400"
+            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-accent-dark-fg"
             : "text-stone-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
         }`}
         aria-label="Grid view"

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -9,9 +9,9 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    "bg-accent dark:bg-teal-400 text-white dark:text-slate-900 hover:bg-accent-hover dark:hover:bg-teal-300 border border-accent dark:border-teal-400",
+    "bg-accent dark:bg-accent-dark text-white hover:bg-accent-hover dark:hover:bg-accent-dark-hover border border-accent dark:border-accent-dark",
   outline:
-    "bg-transparent text-brand-dark dark:text-teal-400 hover:bg-stone-100 dark:hover:bg-slate-700 border border-stone-300 dark:border-slate-600",
+    "bg-transparent text-brand-dark dark:text-accent-dark-fg hover:bg-stone-100 dark:hover:bg-slate-700 border border-stone-300 dark:border-slate-600",
 };
 
 export function Button({
@@ -22,7 +22,7 @@ export function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent dark:focus:ring-teal-400 dark:focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed ${variantClasses[variant]} ${className}`}
+      className={`px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent dark:focus:ring-accent-dark-fg dark:focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed ${variantClasses[variant]} ${className}`}
       {...props}
     >
       {children}

--- a/app/components/ui/Tabs.tsx
+++ b/app/components/ui/Tabs.tsx
@@ -41,7 +41,7 @@ export function Tabs({ tabs, activeTab, onBeforeNavigate }: TabsProps) {
           >
             {tab.label}
             {isActive && (
-              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent dark:bg-teal-400" />
+              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent dark:bg-accent-dark-fg" />
             )}
           </Link>
         );

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,7 @@ function NavigationProgressBar() {
 
   return (
     <div className="fixed top-0 left-0 right-0 z-50 h-1 bg-stone-200 dark:bg-slate-700 overflow-hidden">
-      <div className="h-full bg-accent dark:bg-teal-400 animate-progress-bar" />
+      <div className="h-full bg-accent dark:bg-accent-dark animate-progress-bar" />
     </div>
   );
 }
@@ -174,13 +174,13 @@ export function ErrorBoundary() {
             {statusCode}
           </p>
         )}
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-200 mb-4">
           {title}
         </h1>
         <p className="text-slate-600 dark:text-slate-400 mb-8">{message}</p>
         <Link
           to="/"
-          className="inline-block px-6 py-3 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-lg font-medium hover:opacity-90 transition-opacity"
+          className="inline-block px-6 py-3 bg-accent dark:bg-accent-dark text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
         >
           Back to Home
         </Link>

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -173,7 +173,7 @@ export default function ArticleDetails() {
         {/* Similar Articles Section */}
         {similarArticles.length > 0 && (
           <div className="max-w-7xl mx-auto px-6 py-8">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100 mb-6">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-200 mb-6">
               Similar Articles
             </h2>
             <ArticleGrid
@@ -202,7 +202,7 @@ export function ErrorBoundary() {
         <div className="flex flex-col items-center justify-center min-h-[50vh] px-6">
           {isRouteErrorResponse(error) ? (
             <>
-              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-200 mb-4">
                 {error.status === 404
                   ? "Article Not Found"
                   : `Error ${error.status}`}
@@ -216,7 +216,7 @@ export function ErrorBoundary() {
             </>
           ) : (
             <>
-              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-200 mb-4">
                 Something went wrong
               </h2>
               <p className="text-slate-600 dark:text-slate-400 text-center max-w-md">
@@ -226,7 +226,7 @@ export function ErrorBoundary() {
           )}
           <Link
             to="/"
-            className="mt-8 px-6 py-2 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-md hover:bg-accent-hover dark:hover:bg-teal-300 transition-colors"
+            className="mt-8 px-6 py-2 bg-accent dark:bg-accent-dark text-white rounded-md hover:bg-accent-hover dark:hover:bg-accent-dark-hover transition-colors"
           >
             Return to home
           </Link>

--- a/app/routes/semantic-search.tsx
+++ b/app/routes/semantic-search.tsx
@@ -111,7 +111,7 @@ export default function SemanticSearch() {
               onChange={e => setText(e.target.value)}
               placeholder="Paste a snippet, abstract, or topic description to find related research..."
               rows={4}
-              className="w-full rounded-md border border-stone-300 dark:border-slate-600 bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light px-4 py-3 text-sm placeholder:text-stone-500 dark:placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 resize-y"
+              className="w-full rounded-md border border-stone-300 dark:border-slate-600 bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light px-4 py-3 text-sm placeholder:text-stone-500 dark:placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-accent-dark-fg resize-y"
             />
             <Button
               variant="primary"

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -261,7 +261,7 @@ function CreateTokenForm({
           value={name}
           onChange={e => setName(e.target.value)}
           placeholder="Token name (optional)"
-          className="flex-1 px-3 py-2 text-sm border border-stone-300 dark:border-slate-600 rounded-md bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light placeholder-stone-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400"
+          className="flex-1 px-3 py-2 text-sm border border-stone-300 dark:border-slate-600 rounded-md bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light placeholder-stone-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-accent-dark-fg"
         />
         <Button type="submit" variant="primary" disabled={isCreating}>
           {isCreating ? "Creating..." : "Create Token"}
@@ -469,7 +469,7 @@ export default function Settings() {
               href="/docs/api.html"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-accent dark:bg-teal-400 dark:text-slate-900 rounded-md hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-accent dark:bg-accent-dark rounded-md hover:opacity-90 transition-opacity"
             >
               View API Documentation
               <ArrowRightIcon className="w-4 h-4" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,10 @@ export default {
         accent: "#0f766e",
         "accent-hover": "#0d9488",
         "accent-light": "#ccfbf1",
+        "accent-dark": "#0f766e",
+        "accent-dark-hover": "#115e59",
+        "accent-dark-fg": "#14b8a6",
+        "accent-dark-fg-hover": "#2dd4bf",
       },
       fontFamily: {
         serif: ["Georgia", "Times New Roman", "serif"],


### PR DESCRIPTION
## Appearance Stage B — colour & dark-mode polish

Second of the staged appearance pass. **Stacked on Stage A (#62)** — review/merge #62 first; this PR's base is `appearance/stage-a-criticals`.

### What changed
- **QW-5 · Calm the dark-mode accent (restrained / in-family).** Filled controls used to flip to a vivid near-neon cyan (`teal-300/400`, dark text) in dark mode — a different brand personality from the light forest-teal. Added an `accent-dark` token family (`#0f766e` fill + **white** text, matching the light personality; `teal-500` for foreground lines/text on the dark page) and unified every dark-mode control onto it. No raw `teal-400/300` remain on controls. The semantic-search helper text now keeps the accent in dark too. Measured: dark primary button **5.47:1** (WCAG AA).
- **QW-4 · Liked/disliked legible beyond colour (CVD).** Active thumbs already swapped to a filled icon; added a colour-independent **pill + ring** on the active state so it's distinguishable when hue is removed — verified under injected deuteranopia & protanopia.
- **QW-9 · Halation.** Near-white headings rendered directly on the `#1a1a1a` page softened `slate-100 → slate-200` (still ~13:1); text on lighter card surfaces left untouched.

### Verification
- Repo gate green: `format:check`, `lint`, `typecheck`, **`vitest` 196/196**, `build` (no test changes).
- In-browser render check (offline, dark): dark button contrast **5.47:1**; CVD shots (`__deutan`/`__protan`) confirm the active-thumb cue survives; halation/hero shot for the softened text.
- Adversarial review PASS. Scope stayed dark-only (one light-mode over-reach was caught and reverted).

17 files, +46/−38 — tokens/markup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
