### PR TITLE
Appearance Stage C: designed empty / error / logged-out states

### DIFF
--- a/app/components/article/ArticleCollection.tsx
+++ b/app/components/article/ArticleCollection.tsx
@@ -1,4 +1,7 @@
+import type { ReactNode } from "react";
 import { type Article } from "~/schemas/article";
+import { EmptyState } from "~/components/feedback";
+import { InboxIcon } from "~/components/layout/Icons";
 
 interface ArticleItemProps {
   article: Article;
@@ -11,6 +14,7 @@ export interface ArticleCollectionProps {
   articles: Article[];
   isLoading: boolean;
   emptyMessage?: string;
+  emptyState?: ReactNode;
   onThumbsUp?: (articleId: string, value: boolean) => Promise<void>;
   onThumbsDown?: (articleId: string, value: boolean) => Promise<void>;
   onMarkAsRead?: (articleId: string) => Promise<void>;
@@ -25,6 +29,7 @@ export function ArticleCollection({
   articles,
   isLoading,
   emptyMessage = "No articles found",
+  emptyState,
   onThumbsUp,
   onThumbsDown,
   onMarkAsRead,
@@ -46,11 +51,15 @@ export function ArticleCollection({
 
   if (!isLoading && articles.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 px-4">
-        <p className="text-slate-600 dark:text-accent-dark-fg text-lg">
-          {emptyMessage}
-        </p>
-      </div>
+      <>
+        {emptyState ?? (
+          <EmptyState
+            icon={<InboxIcon />}
+            title="No articles yet"
+            description={emptyMessage}
+          />
+        )}
+      </>
     );
   }
 

--- a/app/components/article/ArticleFeed.tsx
+++ b/app/components/article/ArticleFeed.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { type Article } from "~/schemas/article";
 import type { ViewMode } from "../layout/ViewToggle";
 import { ArticleList } from "./ArticleList";
@@ -11,6 +12,7 @@ interface ArticleFeedProps {
   onThumbsDown?: (articleId: string, value: boolean) => Promise<void>;
   onMarkAsRead?: (articleId: string) => Promise<void>;
   emptyMessage?: string;
+  emptyState?: ReactNode;
 }
 
 export function ArticleFeed({ viewMode, ...props }: ArticleFeedProps) {

--- a/app/components/feedback/EmptyState.test.tsx
+++ b/app/components/feedback/EmptyState.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { EmptyState } from "./EmptyState";
+import { InboxIcon } from "~/components/layout/Icons";
+
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(
+      <MemoryRouter>
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No articles yet"
+          description="New research will appear here."
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("No articles yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("New research will appear here.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders action button when action.to is provided", () => {
+    render(
+      <MemoryRouter>
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No articles"
+          action={{ label: "Browse feed", to: "/" }}
+        />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("button", { name: "Browse feed" })
+    ).toBeInTheDocument();
+  });
+
+  it("fires onClick when action.onClick button is clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <MemoryRouter>
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No articles"
+          action={{ label: "Refresh", onClick }}
+        />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders icon as svg", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <EmptyState icon={<InboxIcon />} title="No articles" />
+      </MemoryRouter>
+    );
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/app/components/feedback/EmptyState.tsx
+++ b/app/components/feedback/EmptyState.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Link } from "@remix-run/react";
+import { Button } from "~/components/ui/Button";
+
+export interface EmptyStateAction {
+  label: string;
+  to?: string;
+  onClick?: () => void;
+}
+
+export interface EmptyStateProps {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: EmptyStateAction;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center text-center px-4 py-16"
+    >
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-stone-200/70 dark:bg-slate-800 [&>svg]:h-8 [&>svg]:w-8 [&>svg]:text-stone-500 dark:[&>svg]:text-slate-400">
+        {icon}
+      </div>
+      <h2 className="text-lg font-semibold text-brand-dark dark:text-brand-light">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-2 max-w-sm text-sm text-slate-600 dark:text-slate-400">
+          {description}
+        </p>
+      )}
+      {action && (
+        <div className="mt-6">
+          {action.to ? (
+            <Link to={action.to}>
+              <Button variant="primary" type="button">
+                {action.label}
+              </Button>
+            </Link>
+          ) : action.onClick ? (
+            <Button variant="primary" type="button" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/feedback/ErrorState.test.tsx
+++ b/app/components/feedback/ErrorState.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ErrorState } from "./ErrorState";
+
+describe("ErrorState", () => {
+  it("renders default title and description", () => {
+    render(
+      <MemoryRouter>
+        <ErrorState />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText("We couldn’t load this content. Please try again.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders custom title and description", () => {
+    render(
+      <MemoryRouter>
+        <ErrorState title="Custom error" description="Custom description" />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Custom error")).toBeInTheDocument();
+    expect(screen.getByText("Custom description")).toBeInTheDocument();
+  });
+
+  it("fires onRetry when retry button is clicked", () => {
+    const onRetry = vi.fn();
+    render(
+      <MemoryRouter>
+        <ErrorState onRetry={onRetry} />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("renders back link when backTo is provided", () => {
+    render(
+      <MemoryRouter>
+        <ErrorState backTo="/" backLabel="Go home" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("button", { name: "Go home" })).toBeInTheDocument();
+  });
+});

--- a/app/components/feedback/ErrorState.tsx
+++ b/app/components/feedback/ErrorState.tsx
@@ -1,0 +1,56 @@
+import { Link } from "@remix-run/react";
+import { Button } from "~/components/ui/Button";
+import { ExclamationTriangleIcon } from "~/components/layout/Icons";
+
+export interface ErrorStateProps {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+  backTo?: string;
+  backLabel?: string;
+}
+
+export function ErrorState({
+  title = "Something went wrong",
+  description = "We couldn’t load this content. Please try again.",
+  onRetry,
+  retryLabel = "Try again",
+  backTo,
+  backLabel = "Back to feed",
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center text-center px-4 py-16"
+    >
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/25 [&>svg]:h-8 [&>svg]:w-8 [&>svg]:text-red-500 dark:[&>svg]:text-red-400">
+        <ExclamationTriangleIcon />
+      </div>
+      <h2 className="text-lg font-semibold text-brand-dark dark:text-brand-light">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-2 max-w-sm text-sm text-slate-600 dark:text-slate-400">
+          {description}
+        </p>
+      )}
+      {(onRetry || backTo) && (
+        <div className="mt-6 flex items-center gap-3">
+          {onRetry && (
+            <Button variant="primary" type="button" onClick={onRetry}>
+              {retryLabel}
+            </Button>
+          )}
+          {backTo && (
+            <Link to={backTo}>
+              <Button variant="outline" type="button">
+                {backLabel}
+              </Button>
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/feedback/LoginGate.test.tsx
+++ b/app/components/feedback/LoginGate.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LoginGate } from "./LoginGate";
+
+describe("LoginGate", () => {
+  it("renders title and description", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate title="Log in required" description="You need to log in." />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Log in required")).toBeInTheDocument();
+    expect(screen.getByText("You need to log in.")).toBeInTheDocument();
+  });
+
+  it("renders default CTA linking to /auth/login", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate title="Log in" description="Please log in." />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole("link", { name: "Log In" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/auth/login");
+  });
+
+  it("renders custom ctaLabel", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate
+          title="Log in"
+          description="Please log in."
+          ctaLabel="Sign In"
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
+  });
+
+  it("renders custom to path", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate title="Log in" description="Please log in." to="/login" />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole("link", { name: "Log In" });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});

--- a/app/components/feedback/LoginGate.tsx
+++ b/app/components/feedback/LoginGate.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Link } from "@remix-run/react";
+import { Button } from "~/components/ui/Button";
+import { LockClosedIcon } from "~/components/layout/Icons";
+
+export interface LoginGateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  to?: string;
+}
+
+export function LoginGate({
+  icon,
+  title,
+  description,
+  ctaLabel = "Log In",
+  to = "/auth/login",
+}: LoginGateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center text-center px-4 py-16">
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-accent-light dark:bg-accent-dark/25 [&>svg]:h-8 [&>svg]:w-8 [&>svg]:text-accent dark:[&>svg]:text-accent-dark-fg">
+        {icon ?? <LockClosedIcon />}
+      </div>
+      <h2 className="text-lg font-semibold text-brand-dark dark:text-brand-light">
+        {title}
+      </h2>
+      <p className="mt-2 max-w-sm text-sm text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+      <div className="mt-6">
+        <Link to={to}>
+          <Button variant="primary" type="button">
+            {ctaLabel}
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/components/feedback/index.ts
+++ b/app/components/feedback/index.ts
@@ -1,0 +1,6 @@
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps, EmptyStateAction } from "./EmptyState";
+export { ErrorState } from "./ErrorState";
+export type { ErrorStateProps } from "./ErrorState";
+export { LoginGate } from "./LoginGate";
+export type { LoginGateProps } from "./LoginGate";

--- a/app/components/layout/Icons.tsx
+++ b/app/components/layout/Icons.tsx
@@ -392,3 +392,79 @@ export function CodeBracketIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function InboxIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"
+      />
+    </svg>
+  );
+}
+
+export function ExclamationTriangleIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+      />
+    </svg>
+  );
+}
+
+export function LockClosedIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+      />
+    </svg>
+  );
+}
+
+export function SparklesIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z"
+      />
+    </svg>
+  );
+}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,9 @@
 import { useState, useCallback } from "react";
-import { useSearchParams, useLoaderData } from "@remix-run/react";
+import {
+  useSearchParams,
+  useLoaderData,
+  useRevalidator,
+} from "@remix-run/react";
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 import { TopBar } from "~/components/layout/TopBar";
@@ -14,6 +18,8 @@ import { useInfiniteScroll } from "~/hooks/useInfiniteScroll";
 import { useViewPreference } from "~/hooks/useViewPreference";
 import { createAuthenticatedFetch } from "~/server/auth.server";
 import { parseArticlesResponse, type Article } from "~/schemas/article";
+import { EmptyState, ErrorState } from "~/components/feedback";
+import { SearchIcon, InboxIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -119,11 +125,18 @@ export default function Index() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useArticles(searchQuery, { initialArticles });
 
   // Combine loader and fetch errors
   const error = loaderError ?? fetchError?.message;
+
+  const revalidator = useRevalidator();
+  const handleRetry = useCallback(() => {
+    revalidator.revalidate();
+    refetch();
+  }, [revalidator, refetch]);
 
   // Shared feedback handlers with optimistic updates
   const { handleThumbsUp, handleThumbsDown, handleMarkAsRead } =
@@ -175,9 +188,7 @@ export default function Index() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {error && articles.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} />
           ) : (
             <>
               <ArticleFeed
@@ -191,6 +202,25 @@ export default function Index() {
                   searchQuery
                     ? `No articles found for "${searchQuery}"`
                     : "No articles found"
+                }
+                emptyState={
+                  searchQuery ? (
+                    <EmptyState
+                      icon={<SearchIcon />}
+                      title={`No results for "${searchQuery}"`}
+                      description="Try a different keyword, or clear the search to see the full feed."
+                      action={{
+                        label: "Clear search",
+                        onClick: () => handleSearch(""),
+                      }}
+                    />
+                  ) : (
+                    <EmptyState
+                      icon={<InboxIcon />}
+                      title="No articles yet"
+                      description="New AI-safety research will appear here as it's published."
+                    />
+                  )
                 }
               />
 

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -1,10 +1,9 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { ChatPanel } from "~/components/chat/ChatPanel";
 import { getServerAuthContext } from "~/server/auth.server";
@@ -13,6 +12,8 @@ import {
   type Conversation,
   type UserId,
 } from "~/server/chat.server";
+import { LoginGate } from "~/components/feedback";
+import { ChatBubbleIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -76,16 +77,11 @@ export default function Chat() {
         {/* Content */}
         {!isAuthenticated ? (
           <div className="max-w-7xl mx-auto">
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to chat with the AI research assistant.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<ChatBubbleIcon />}
+              title="Chat with the research assistant"
+              description="Log in to ask questions about alignment research and get cited answers."
+            />
           </div>
         ) : (
           <div className="max-w-7xl w-full mx-auto px-6 mt-4 mb-4 flex-1 min-h-0">

--- a/app/routes/disliked.tsx
+++ b/app/routes/disliked.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useUserArticles } from "~/hooks/useUserArticles";
@@ -15,6 +14,8 @@ import {
   fetchArticlesFromApi,
   createPaginationParams,
 } from "~/server/articles.server";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { ThumbsDownIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -53,6 +54,7 @@ export default function Disliked() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useUserArticles("disliked", { initialArticles });
 
@@ -66,9 +68,14 @@ export default function Disliked() {
   });
 
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
 
   const showLoginPrompt = !isAuthenticated;
   const error = loaderError ?? fetchError?.message;
+  const handleRetry = () => {
+    revalidator.revalidate();
+    refetch();
+  };
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -88,20 +95,13 @@ export default function Disliked() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see your disliked articles.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Disliked Articles
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<ThumbsDownIcon />}
+              title="Your disliked articles"
+              description="Log in to track what you've set aside and tune your feed."
+            />
           ) : error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} backTo="/" />
           ) : (
             <>
               <ArticleFeed
@@ -112,6 +112,14 @@ export default function Disliked() {
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
                 emptyMessage="No disliked articles. You haven't disliked anything yet."
+                emptyState={
+                  <EmptyState
+                    icon={<ThumbsDownIcon />}
+                    title="Nothing disliked"
+                    description="Articles you dislike are hidden from your feed and listed here."
+                    action={{ label: "Browse the feed", to: "/" }}
+                  />
+                }
               />
 
               {hasMore && (

--- a/app/routes/liked.tsx
+++ b/app/routes/liked.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useUserArticles } from "~/hooks/useUserArticles";
@@ -15,6 +14,8 @@ import {
   fetchArticlesFromApi,
   createPaginationParams,
 } from "~/server/articles.server";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { ThumbsUpIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -53,6 +54,7 @@ export default function Liked() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useUserArticles("liked", { initialArticles });
 
@@ -66,9 +68,14 @@ export default function Liked() {
   });
 
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
 
   const showLoginPrompt = !isAuthenticated;
   const error = loaderError ?? fetchError?.message;
+  const handleRetry = () => {
+    revalidator.revalidate();
+    refetch();
+  };
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -88,20 +95,13 @@ export default function Liked() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see your liked articles.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Liked Articles
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<ThumbsUpIcon />}
+              title="Your liked articles"
+              description="Log in to keep a personal library of the research you've liked."
+            />
           ) : error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} backTo="/" />
           ) : (
             <>
               <ArticleFeed
@@ -112,6 +112,14 @@ export default function Liked() {
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
                 emptyMessage="No liked articles yet. Like some articles to see them here!"
+                emptyState={
+                  <EmptyState
+                    icon={<ThumbsUpIcon />}
+                    title="No liked articles yet"
+                    description="Like an article and it'll collect here for easy reference."
+                    action={{ label: "Browse the feed", to: "/" }}
+                  />
+                }
               />
 
               {hasMore && (

--- a/app/routes/recommended.tsx
+++ b/app/routes/recommended.tsx
@@ -1,12 +1,12 @@
 import React, { Suspense } from "react";
+import type { ReactNode } from "react";
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData, Await } from "@remix-run/react";
+import { useLoaderData, Await, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle, type ViewMode } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useViewPreference } from "~/hooks/useViewPreference";
@@ -15,6 +15,8 @@ import {
   type FetchArticlesResult,
 } from "~/server/articles.server";
 import { RecommendationsLoading } from "~/components/article/RecommendationsLoading";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { SparklesIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -51,9 +53,11 @@ type LoaderData = {
 function RecommendedContent({
   articlesData,
   viewMode,
+  emptyState,
 }: {
   articlesData: FetchArticlesResult;
   viewMode: ViewMode;
+  emptyState?: ReactNode;
 }) {
   const { handleThumbsUp, handleThumbsDown, handleMarkAsRead } =
     useArticleFeedbackHandlers();
@@ -67,6 +71,7 @@ function RecommendedContent({
       onThumbsDown={handleThumbsDown}
       onMarkAsRead={handleMarkAsRead}
       emptyMessage="No recommendations yet. Like some articles to get personalized suggestions!"
+      emptyState={emptyState}
     />
   );
 }
@@ -74,7 +79,17 @@ function RecommendedContent({
 export default function Recommended() {
   const { isAuthenticated, articlesData } = useLoaderData<LoaderData>();
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
   const showLoginPrompt = !isAuthenticated;
+
+  const emptyState = (
+    <EmptyState
+      icon={<SparklesIcon />}
+      title="No recommendations yet"
+      description="Like a few articles and we'll surface related research here."
+      action={{ label: "Browse the feed", to: "/" }}
+    />
+  );
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -94,27 +109,21 @@ export default function Recommended() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see personalized recommendations based on your
-                interests.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Recommendations
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<SparklesIcon />}
+              title="Personalised recommendations"
+              description="Log in and like a few articles to get research picked for your interests."
+            />
           ) : (
             <Suspense fallback={<RecommendationsLoading />}>
               <Await
                 resolve={articlesData}
                 errorElement={
-                  <div className="flex flex-col items-center justify-center py-16 px-4">
-                    <p className="text-red-600 dark:text-red-400 text-lg">
-                      Failed to load recommendations. Please try again later.
-                    </p>
-                  </div>
+                  <ErrorState
+                    title="Couldn't load recommendations"
+                    description="Something went wrong fetching your picks."
+                    onRetry={() => revalidator.revalidate()}
+                  />
                 }
               >
                 {/* Cast needed: Remix's Await type inference doesn't preserve deferred promise types */}
@@ -123,6 +132,7 @@ export default function Recommended() {
                     <RecommendedContent
                       articlesData={resolved}
                       viewMode={viewMode}
+                      emptyState={emptyState}
                     />
                   )) as (value: unknown) => React.ReactNode
                 }

--- a/app/routes/semantic-search.tsx
+++ b/app/routes/semantic-search.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { MetaFunction } from "@remix-run/cloudflare";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
@@ -10,6 +10,8 @@ import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useViewPreference } from "~/hooks/useViewPreference";
 import { parseArticlesResponse, type Article } from "~/schemas/article";
+import { EmptyState, ErrorState } from "~/components/feedback";
+import { SearchIcon, SparklesIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -40,53 +42,62 @@ export default function SemanticSearch() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
+  const lastQueryRef = useRef("");
 
   const [viewMode, setViewMode] = useViewPreference();
 
   const { handleThumbsUp, handleThumbsDown, handleMarkAsRead } =
     useArticleFeedbackHandlers({ setArticles });
 
+  const runSearch = useCallback(async (query: string) => {
+    setIsLoading(true);
+    setError(null);
+    setHasSearched(true);
+
+    try {
+      const response = await fetch("/api/articles/semantic-search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: query, limit: 20 }),
+      });
+
+      if (!response.ok) {
+        setError("Search failed. Please try again later.");
+        setArticles([]);
+        return;
+      }
+
+      const result = parseArticlesResponse(await response.json());
+
+      if (!result.success) {
+        setError("Failed to parse search results.");
+        setArticles([]);
+        return;
+      }
+
+      setArticles(result.data.data);
+    } catch {
+      setError("Search failed. Please check your connection and try again.");
+      setArticles([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
       const trimmed = text.trim();
       if (!trimmed) return;
-
-      setIsLoading(true);
-      setError(null);
-      setHasSearched(true);
-
-      try {
-        const response = await fetch("/api/articles/semantic-search", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text: trimmed, limit: 20 }),
-        });
-
-        if (!response.ok) {
-          setError("Search failed. Please try again later.");
-          setArticles([]);
-          return;
-        }
-
-        const result = parseArticlesResponse(await response.json());
-
-        if (!result.success) {
-          setError("Failed to parse search results.");
-          setArticles([]);
-          return;
-        }
-
-        setArticles(result.data.data);
-      } catch {
-        setError("Search failed. Please check your connection and try again.");
-        setArticles([]);
-      } finally {
-        setIsLoading(false);
-      }
+      lastQueryRef.current = trimmed;
+      runSearch(trimmed);
     },
-    [text]
+    [text, runSearch]
   );
+
+  const retry = useCallback(() => {
+    if (lastQueryRef.current) runSearch(lastQueryRef.current);
+  }, [runSearch]);
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -126,9 +137,7 @@ export default function SemanticSearch() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={retry} />
           ) : (
             <ArticleFeed
               viewMode={viewMode}
@@ -141,6 +150,21 @@ export default function SemanticSearch() {
                 hasSearched
                   ? "No related articles found for your text."
                   : "Paste text above to find similar research."
+              }
+              emptyState={
+                hasSearched ? (
+                  <EmptyState
+                    icon={<SearchIcon />}
+                    title="No related research found"
+                    description="No semantically similar articles turned up. Try rephrasing or adding more detail."
+                  />
+                ) : (
+                  <EmptyState
+                    icon={<SparklesIcon />}
+                    title="Find related research"
+                    description="Paste an abstract, snippet, or topic above to discover semantically similar papers."
+                  />
+                )
               }
             />
           )}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,5 +1,4 @@
 import type { MetaFunction } from "@remix-run/cloudflare";
-import { Link } from "@remix-run/react";
 import { z } from "zod";
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "~/root";
@@ -11,7 +10,9 @@ import {
   ClipboardIcon,
   DownloadIcon,
   ArrowRightIcon,
+  SettingsIcon,
 } from "~/components/layout/Icons";
+import { LoginGate } from "~/components/feedback";
 import { formatPublishedDate } from "~/utils/formatting";
 
 export const meta: MetaFunction = () => {
@@ -357,16 +358,11 @@ export default function Settings() {
           </h1>
 
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to manage your settings.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<SettingsIcon />}
+              title="Manage your account"
+              description="Log in to create API tokens and configure the MCP integration."
+            />
           ) : (
             <section>
               <h2 className="text-lg font-medium text-brand-dark dark:text-brand-light mb-4">

--- a/app/routes/unreviewed.tsx
+++ b/app/routes/unreviewed.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useUserArticles } from "~/hooks/useUserArticles";
@@ -15,6 +14,8 @@ import {
   fetchArticlesFromApi,
   createPaginationParams,
 } from "~/server/articles.server";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { CheckCircleIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -56,6 +57,7 @@ export default function Unreviewed() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useUserArticles("unreviewed", { initialArticles });
 
@@ -69,9 +71,14 @@ export default function Unreviewed() {
   });
 
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
 
   const showLoginPrompt = !isAuthenticated;
   const error = loaderError ?? fetchError?.message;
+  const handleRetry = () => {
+    revalidator.revalidate();
+    refetch();
+  };
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -91,20 +98,13 @@ export default function Unreviewed() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see your unreviewed articles.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Unreviewed Articles
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<CheckCircleIcon />}
+              title="Pick up where you left off"
+              description="Log in to see the research you haven't reviewed yet."
+            />
           ) : error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} backTo="/" />
           ) : (
             <>
               <ArticleFeed
@@ -115,6 +115,14 @@ export default function Unreviewed() {
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
                 emptyMessage="No unreviewed articles. You've reviewed everything!"
+                emptyState={
+                  <EmptyState
+                    icon={<CheckCircleIcon />}
+                    title="All caught up"
+                    description="You've reviewed everything. New articles will show up here."
+                    action={{ label: "Browse the feed", to: "/" }}
+                  />
+                }
               />
 
               {hasMore && (

--- a/app/test/settings.test.tsx
+++ b/app/test/settings.test.tsx
@@ -30,9 +30,7 @@ describe("Settings route", () => {
   it("shows login prompt when not authenticated", async () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false });
     renderSettings();
-    expect(
-      await screen.findByText(/Log in to manage your settings/i)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Manage your account/i)).toBeInTheDocument();
   });
 
   it("shows API Tokens section when authenticated", async () => {


### PR DESCRIPTION
## Appearance Stage C — designed empty / error / logged-out states (ST-1)

Third of the staged appearance pass. **Stacked on Stage B (#63)** — base is `appearance/stage-b-colour`; merge #62 → #63 → this in order.

The review found the app's non-data states were under-designed: empty = one grey line, errors = red text with **no retry**, logged-out gates = a one-line prompt — five+ near-identical "blank canvases". This stage makes them real, on-brand states.

### What changed
- **3 shared components** in `app/components/feedback/`: `EmptyState`, `ErrorState` (with a working **Retry**), and `LoginGate` — icon-in-soft-badge + headline + supportive body + a relevant action, on-brand and dark-mode correct. Plus 4 new outline icons (Inbox, ExclamationTriangle, LockClosed, Sparkles) matching the existing family.
- **Wired across 8 screens** — feed, liked, disliked, unreviewed, recommended, semantic-search, chat, settings — replacing every bare empty `<p>`, retry-less red error, and one-line login gate. `ArticleCollection` gained an `emptyState` prop threaded through feed/list/grid, with search-aware copy ("No results for …" + Clear search).
- **Real error recovery:** loader errors retry via `useRevalidator().revalidate()` + the hook's `refetch()`; semantic-search re-runs the last query; recommended retries the deferred `Await`. The feed "Try again" was click-verified to fire a fresh `/api/articles` request.

### Verification
- Repo gate green: `format:check`, `lint`, `typecheck`, **`vitest` 208/208** (12 new component tests; `settings.test.tsx` copy updated), `build`.
- Render gallery (offline, light + dark, 17 states) — each judged genuinely designed (icon + headline + body + action, good rhythm, dark-mode correct).
- Adversarial review PASS (all 6 criteria, incl. real-retry and scope).

19 files, +621/−136 (7 new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
