### PR TITLE
Appearance Stage D: typography & iconography polish

### DIFF
--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -1,6 +1,10 @@
 import { useNavigate } from "@remix-run/react";
 import { useState } from "react";
-import { type Article, formatPublishedDate } from "~/schemas/article";
+import {
+  type Article,
+  formatPublishedDate,
+  formatAuthorsByline,
+} from "~/schemas/article";
 import {
   ThumbsUpIcon,
   ThumbsUpFilledIcon,
@@ -67,18 +71,20 @@ export function ArticleCard({
       <div
         className={`h-12 px-4 flex items-center justify-between gap-2 flex-shrink-0 ${getCategoryHeaderColor(article.category)}`}
       >
-        <span className="font-medium text-sm truncate">
+        <span className="font-medium text-sm truncate min-w-0 flex-1">
           {getSourceDisplayName(article.source, article.authors)}
         </span>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 flex-shrink-0 max-w-[45%]">
           {article.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20 min-w-0 truncate">
               {article.category}
             </span>
           )}
-          {isVideoSource(article.source) && <PlayIcon className="w-5 h-5" />}
+          {isVideoSource(article.source) && (
+            <PlayIcon className="w-4 h-4 flex-shrink-0" />
+          )}
           {haveRead && (
-            <span title="Read">
+            <span title="Read" className="flex-shrink-0">
               <CheckCircleIcon className="w-4 h-4 text-green-600 dark:text-green-300" />
             </span>
           )}
@@ -114,7 +120,7 @@ export function ArticleCard({
 
         {/* Author */}
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-1 truncate">
-          {article.authors}
+          {formatAuthorsByline(article.authors)}
         </p>
 
         {/* Title */}

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -116,7 +116,7 @@ export function ArticleRow({
               {article.category}
             </span>
           )}
-          {isVideoSource(article.source) && <PlayIcon className="w-5 h-5" />}
+          {isVideoSource(article.source) && <PlayIcon className="w-4 h-4" />}
           {haveRead && (
             <span title="Read">
               <CheckCircleIcon className="w-4 h-4 text-green-600 dark:text-green-300" />
@@ -143,6 +143,7 @@ export function ArticleRow({
                 <ThumbnailPlaceholder
                   source={article.source}
                   className="h-full w-full"
+                  iconClassName="w-7 h-7"
                 />
               )}
             </div>
@@ -154,7 +155,7 @@ export function ArticleRow({
                 onClick={handleMarkAsRead}
                 className="group block"
               >
-                <h3 className="font-medium text-slate-900 dark:text-slate-100 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors">
+                <h3 className="font-medium text-slate-900 dark:text-slate-100 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors line-clamp-3">
                   {article.title}
                 </h3>
               </a>
@@ -178,7 +179,7 @@ export function ArticleRow({
           <div className="min-w-0 md:col-span-3">
             <p
               ref={summaryRef}
-              className="text-sm text-slate-600 dark:text-slate-400 line-clamp-4"
+              className="text-sm text-slate-600 dark:text-slate-400 line-clamp-4 max-w-prose"
             >
               {article.summary}
             </p>

--- a/app/components/article/LoadingCard.tsx
+++ b/app/components/article/LoadingCard.tsx
@@ -1,8 +1,11 @@
 export function LoadingCard() {
   return (
     <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden animate-pulse h-full flex flex-col">
-      {/* Header strip placeholder */}
-      <div className="h-12 bg-stone-300 dark:bg-slate-600 flex-shrink-0" />
+      {/* Header strip placeholder - mirrors the coloured category band */}
+      <div className="h-12 bg-stone-300 dark:bg-slate-700 border-l-4 border-stone-400 dark:border-slate-600 flex-shrink-0" />
+
+      {/* Thumbnail block - mirrors the aspect-video thumbnail */}
+      <div className="aspect-video w-full bg-stone-100 dark:bg-stone-800" />
 
       {/* Content */}
       <div className="p-4 flex flex-col flex-grow">

--- a/app/components/article/LoadingRow.tsx
+++ b/app/components/article/LoadingRow.tsx
@@ -1,22 +1,25 @@
 export function LoadingRow() {
   return (
     <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden animate-pulse">
-      {/* Header strip placeholder */}
-      <div className="h-10 bg-stone-300 dark:bg-slate-600" />
+      {/* Header strip placeholder - mirrors the coloured category band */}
+      <div className="h-10 bg-stone-300 dark:bg-slate-700 border-l-4 border-stone-400 dark:border-slate-600" />
 
-      {/* Two-column content placeholder */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
-        {/* Left: title/author */}
-        <div>
-          <div className="space-y-2 mb-2">
-            <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-full" />
-            <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-3/4" />
+      {/* Two-column content placeholder (2fr / 3fr like the row) */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 p-4">
+        {/* Left: thumbnail + title/author */}
+        <div className="md:col-span-2 flex gap-3">
+          <div className="hidden sm:block flex-shrink-0 w-16 h-16 rounded bg-stone-100 dark:bg-stone-800" />
+          <div className="min-w-0 flex-1">
+            <div className="space-y-2 mb-2">
+              <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-full" />
+              <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-3/4" />
+            </div>
+            <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-1/2" />
           </div>
-          <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-1/2" />
         </div>
 
         {/* Right: summary */}
-        <div className="space-y-2">
+        <div className="md:col-span-3 space-y-2">
           <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-full" />
           <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-full" />
           <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-2/3" />

--- a/app/components/article/ThumbnailPlaceholder.tsx
+++ b/app/components/article/ThumbnailPlaceholder.tsx
@@ -3,19 +3,21 @@ import { getSourcePlaceholderIcon } from "~/constants/sourceIcons";
 interface ThumbnailPlaceholderProps {
   source: string;
   className?: string;
+  iconClassName?: string;
 }
 
 export function ThumbnailPlaceholder({
   source,
   className = "",
+  iconClassName = "w-10 h-10",
 }: ThumbnailPlaceholderProps) {
   const Icon = getSourcePlaceholderIcon(source);
   return (
     <div
-      className={`flex items-center justify-center bg-stone-100 dark:bg-slate-700 ${className}`}
+      className={`flex items-center justify-center bg-stone-100 dark:bg-stone-800 ${className}`}
       data-testid="thumbnail-placeholder"
     >
-      <Icon className="w-10 h-10 text-stone-400 dark:text-slate-500" />
+      <Icon className={`${iconClassName} text-stone-400 dark:text-stone-600`} />
     </div>
   );
 }

--- a/app/components/layout/Icons.tsx
+++ b/app/components/layout/Icons.tsx
@@ -92,7 +92,7 @@ export function CheckCircleIcon(props: IconProps) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={2}
+      strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
       {...props}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -148,7 +148,7 @@ export function ErrorBoundary() {
     statusCode = error.status;
     if (error.status === 404) {
       title = "Page not found";
-      message = "The page you're looking for doesn't exist.";
+      message = "The page you’re looking for doesn’t exist.";
     } else if (error.status === 500) {
       title = "Server error";
       message = "Something went wrong on our end. Please try again later.";

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -232,7 +232,7 @@ export default function Index() {
               {/* End of results indicator */}
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -129,7 +129,7 @@ export default function ArticleDetails() {
           <div className="max-w-4xl mx-auto px-6 pb-8">
             <div className="bg-stone-50 dark:bg-slate-800 rounded-lg p-6 shadow-sm">
               <div className="flex items-center gap-3 mb-4">
-                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
                   Analysis
                 </h2>
                 {article.category && (
@@ -139,16 +139,16 @@ export default function ArticleDetails() {
                 )}
               </div>
 
-              <p className="text-slate-700 dark:text-slate-300 mb-4">
+              <p className="text-slate-700 dark:text-slate-300 mb-4 max-w-prose">
                 {article.summary}
               </p>
 
               {article.key_points && article.key_points.length > 0 && (
                 <div className="mb-4">
-                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+                  <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
                     Key Points
                   </h3>
-                  <ul className="list-disc list-inside space-y-1 text-slate-700 dark:text-slate-300">
+                  <ul className="list-disc list-inside space-y-1 text-slate-700 dark:text-slate-300 max-w-prose">
                     {article.key_points.map((point, i) => (
                       <li key={i}>{point}</li>
                     ))}
@@ -158,10 +158,10 @@ export default function ArticleDetails() {
 
               {article.implication && (
                 <div>
-                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+                  <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
                     Implications for AI Alignment
                   </h3>
-                  <p className="text-slate-700 dark:text-slate-300">
+                  <p className="text-slate-700 dark:text-slate-300 max-w-prose">
                     {article.implication}
                   </p>
                 </div>
@@ -173,7 +173,7 @@ export default function ArticleDetails() {
         {/* Similar Articles Section */}
         {similarArticles.length > 0 && (
           <div className="max-w-7xl mx-auto px-6 py-8">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-200 mb-6">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-200 mb-6">
               Similar Articles
             </h2>
             <ArticleGrid
@@ -209,7 +209,7 @@ export function ErrorBoundary() {
               </h2>
               <p className="text-slate-600 dark:text-slate-400 text-center max-w-md">
                 {error.status === 404
-                  ? "The article you're looking for doesn't exist or may have been removed."
+                  ? "The article you’re looking for doesn’t exist or may have been removed."
                   : error.data ||
                     "Something went wrong while loading this article."}
               </p>

--- a/app/routes/disliked.tsx
+++ b/app/routes/disliked.tsx
@@ -111,7 +111,7 @@ export default function Disliked() {
                 onThumbsUp={handleThumbsUp}
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
-                emptyMessage="No disliked articles. You haven't disliked anything yet."
+                emptyMessage="No disliked articles. You haven’t disliked anything yet."
                 emptyState={
                   <EmptyState
                     icon={<ThumbsDownIcon />}
@@ -128,7 +128,7 @@ export default function Disliked() {
 
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/routes/liked.tsx
+++ b/app/routes/liked.tsx
@@ -128,7 +128,7 @@ export default function Liked() {
 
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -166,7 +166,7 @@ function NewTokenDisplay({
         </button>
       </div>
       <Button variant="outline" onClick={onDismiss} className="text-xs">
-        I&apos;ve copied the token
+        I’ve copied the token
       </Button>
     </div>
   );

--- a/app/routes/unreviewed.tsx
+++ b/app/routes/unreviewed.tsx
@@ -101,7 +101,7 @@ export default function Unreviewed() {
             <LoginGate
               icon={<CheckCircleIcon />}
               title="Pick up where you left off"
-              description="Log in to see the research you haven't reviewed yet."
+              description="Log in to see the research you haven’t reviewed yet."
             />
           ) : error ? (
             <ErrorState description={error} onRetry={handleRetry} backTo="/" />
@@ -114,12 +114,12 @@ export default function Unreviewed() {
                 onThumbsUp={handleThumbsUp}
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
-                emptyMessage="No unreviewed articles. You've reviewed everything!"
+                emptyMessage="No unreviewed articles. You’ve reviewed everything!"
                 emptyState={
                   <EmptyState
                     icon={<CheckCircleIcon />}
                     title="All caught up"
-                    description="You've reviewed everything. New articles will show up here."
+                    description="You’ve reviewed everything. New articles will show up here."
                     action={{ label: "Browse the feed", to: "/" }}
                   />
                 }
@@ -131,7 +131,7 @@ export default function Unreviewed() {
 
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/schemas/article.test.ts
+++ b/app/schemas/article.test.ts
@@ -3,6 +3,7 @@ import {
   ArticleSchema,
   ArticlesResponseSchema,
   parseArticlesResponse,
+  formatAuthorsByline,
 } from "./article";
 
 const validArticle = {
@@ -124,6 +125,34 @@ describe("ArticlesResponseSchema", () => {
     if (result.success) {
       expect(result.data.data).toHaveLength(0);
     }
+  });
+});
+
+describe("formatAuthorsByline", () => {
+  it("returns a single author unchanged", () => {
+    expect(formatAuthorsByline("Jane Doe")).toBe("Jane Doe");
+  });
+
+  it("collapses a comma-separated list to first author + others", () => {
+    expect(
+      formatAuthorsByline("Jane Doe, John Smith, Alex Lee, Sam Park")
+    ).toBe("Jane Doe +3 others");
+  });
+
+  it("handles 'and' separators and uses singular for one extra", () => {
+    expect(formatAuthorsByline("Jane Doe and John Smith")).toBe(
+      "Jane Doe +1 other"
+    );
+  });
+
+  it("respects a higher maxNames before collapsing", () => {
+    expect(formatAuthorsByline("Jane Doe, John Smith, Alex Lee", 2)).toBe(
+      "Jane Doe, John Smith +1 other"
+    );
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(formatAuthorsByline("")).toBe("");
   });
 });
 

--- a/app/schemas/article.ts
+++ b/app/schemas/article.ts
@@ -47,5 +47,24 @@ export function parseArticlesResponse(
   return { success: true, data: result.data };
 }
 
+/**
+ * Format an author list into a compact byline for tight slots.
+ *
+ * Long lists are collapsed to "First Author +N others" so a truncated
+ * byline never falls mid-surname. Lists with `maxNames` or fewer authors
+ * are returned unchanged.
+ */
+export function formatAuthorsByline(authors: string, maxNames = 1): string {
+  if (!authors) return authors;
+  const names = authors
+    .split(/,|\band\b/)
+    .map(name => name.trim())
+    .filter(Boolean);
+  if (names.length <= maxNames) return authors;
+  const shown = names.slice(0, maxNames).join(", ");
+  const remaining = names.length - maxNames;
+  return `${shown} +${remaining} other${remaining === 1 ? "" : "s"}`;
+}
+
 // Re-export formatting utility for convenience
 export { formatPublishedDate } from "~/utils/formatting";


### PR DESCRIPTION
## Appearance Stage D — typography & iconography polish

Fourth of the staged appearance pass. **Stacked on Stage C (#64)** — base is `appearance/stage-c-states`; merge #62 → #63 → #64 → this in order.

### What changed
- **QW-6 · Truncation.** The grid card's source name was starved by the category chip ("DeepMind Technical" → "DeepMin…"); it now gets layout priority (`flex-1 min-w-0`) with the chip capped, so source names render in full. New `formatAuthorsByline()` helper turns an 8-author byline into "Jane Doe +7 others" (clean truncation, +5 vitest cases).
- **QW-8 · Icons.** Normalised icon stroke to the family `1.5` (`CheckCircleIcon` was `2`); matched co-located header-strip icon sizes (`PlayIcon` 20→16px); `ThumbnailPlaceholder` icon sized for the small list slot and its dark tone warmed to match the card.
- **QW-9 · Micro-typography.** Curly apostrophes/quotes across visible copy; the loading skeleton rebuilt to mirror the real card (category-band header + distinct thumbnail block, 2fr/3fr row) with warm dark tones, instead of one flat grey block. (Halation was already handled in Stage B.)
- **ST-3 · Hierarchy & measure.** Detail "Analysis" heading now ranks ≥ "Similar Articles"; overlines crisped to eyebrows; `max-w-prose` caps the reading measure (~65–75ch) without disturbing the card grid.

### Verification
- Repo gate green: `format:check`, `lint`, `typecheck`, **`vitest` 213/213** (+5 byline tests), `build`.
- Render gallery (offline, light + dark, 10 shots) judged PASS on all six criteria.
- Adversarial review PASS; scope excluded palette/elevation/layout/ViewToggle (Stage E).

15 files, +106/−43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
