### PR TITLE
Appearance overhaul: consolidate Stages B–E onto main

### DIFF
--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -65,7 +65,7 @@ export function ArticleCard({
       target="_blank"
       rel="noopener noreferrer"
       onClick={handleMarkAsRead}
-      className="flex flex-col bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm hover:shadow-md transition-shadow overflow-hidden group h-full"
+      className="flex flex-col bg-stone-50 dark:bg-slate-800 rounded-lg shadow shadow-stone-300/50 hover:shadow-md transition-shadow overflow-hidden group h-full dark:border dark:border-slate-700/70 dark:shadow-lg dark:shadow-black/30"
     >
       {/* Source header strip */}
       <div
@@ -113,7 +113,7 @@ export function ArticleCard({
       <div className="p-4 flex flex-col flex-grow">
         {/* Date */}
         {article.published_at && (
-          <div className="text-xs text-slate-600 dark:text-slate-300 mb-2">
+          <div className="text-[13px] text-slate-600 dark:text-slate-300 mb-2">
             {formatPublishedDate(article.published_at)}
           </div>
         )}

--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -1,6 +1,10 @@
 import { useNavigate } from "@remix-run/react";
 import { useState } from "react";
-import { type Article, formatPublishedDate } from "~/schemas/article";
+import {
+  type Article,
+  formatPublishedDate,
+  formatAuthorsByline,
+} from "~/schemas/article";
 import {
   ThumbsUpIcon,
   ThumbsUpFilledIcon,
@@ -67,18 +71,20 @@ export function ArticleCard({
       <div
         className={`h-12 px-4 flex items-center justify-between gap-2 flex-shrink-0 ${getCategoryHeaderColor(article.category)}`}
       >
-        <span className="font-medium text-sm truncate">
+        <span className="font-medium text-sm truncate min-w-0 flex-1">
           {getSourceDisplayName(article.source, article.authors)}
         </span>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 flex-shrink-0 max-w-[45%]">
           {article.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20">
+            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20 min-w-0 truncate">
               {article.category}
             </span>
           )}
-          {isVideoSource(article.source) && <PlayIcon className="w-5 h-5" />}
+          {isVideoSource(article.source) && (
+            <PlayIcon className="w-4 h-4 flex-shrink-0" />
+          )}
           {haveRead && (
-            <span title="Read">
+            <span title="Read" className="flex-shrink-0">
               <CheckCircleIcon className="w-4 h-4 text-green-600 dark:text-green-300" />
             </span>
           )}
@@ -114,7 +120,7 @@ export function ArticleCard({
 
         {/* Author */}
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-1 truncate">
-          {article.authors}
+          {formatAuthorsByline(article.authors)}
         </p>
 
         {/* Title */}

--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -131,8 +131,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsUp}
             disabled={isUpdating}
-            className={`flex items-center gap-1 hover:text-green-600 dark:hover:text-green-400 transition-colors ${
-              thumbsUp ? "text-green-600 dark:text-green-400" : ""
+            className={`flex items-center gap-1 rounded-full px-2 py-1 transition-colors ${
+              thumbsUp
+                ? "text-green-600 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/50 dark:ring-green-400/50"
+                : "hover:text-green-600 dark:hover:text-green-400"
             }`}
             aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
           >
@@ -146,8 +148,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsDown}
             disabled={isUpdating}
-            className={`flex items-center gap-1 hover:text-red-600 dark:hover:text-red-400 transition-colors ${
-              thumbsDown ? "text-red-600 dark:text-red-400" : ""
+            className={`flex items-center gap-1 rounded-full px-2 py-1 transition-colors ${
+              thumbsDown
+                ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/50 dark:ring-red-400/50"
+                : "hover:text-red-600 dark:hover:text-red-400"
             }`}
             aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
           >

--- a/app/components/article/ArticleCollection.tsx
+++ b/app/components/article/ArticleCollection.tsx
@@ -47,7 +47,7 @@ export function ArticleCollection({
   if (!isLoading && articles.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-4">
-        <p className="text-slate-600 dark:text-slate-300 text-lg">
+        <p className="text-slate-600 dark:text-accent-dark-fg text-lg">
           {emptyMessage}
         </p>
       </div>

--- a/app/components/article/ArticleCollection.tsx
+++ b/app/components/article/ArticleCollection.tsx
@@ -1,4 +1,7 @@
+import type { ReactNode } from "react";
 import { type Article } from "~/schemas/article";
+import { EmptyState } from "~/components/feedback";
+import { InboxIcon } from "~/components/layout/Icons";
 
 interface ArticleItemProps {
   article: Article;
@@ -11,6 +14,7 @@ export interface ArticleCollectionProps {
   articles: Article[];
   isLoading: boolean;
   emptyMessage?: string;
+  emptyState?: ReactNode;
   onThumbsUp?: (articleId: string, value: boolean) => Promise<void>;
   onThumbsDown?: (articleId: string, value: boolean) => Promise<void>;
   onMarkAsRead?: (articleId: string) => Promise<void>;
@@ -25,6 +29,7 @@ export function ArticleCollection({
   articles,
   isLoading,
   emptyMessage = "No articles found",
+  emptyState,
   onThumbsUp,
   onThumbsDown,
   onMarkAsRead,
@@ -46,11 +51,15 @@ export function ArticleCollection({
 
   if (!isLoading && articles.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 px-4">
-        <p className="text-slate-600 dark:text-accent-dark-fg text-lg">
-          {emptyMessage}
-        </p>
-      </div>
+      <>
+        {emptyState ?? (
+          <EmptyState
+            icon={<InboxIcon />}
+            title="No articles yet"
+            description={emptyMessage}
+          />
+        )}
+      </>
     );
   }
 

--- a/app/components/article/ArticleFeed.tsx
+++ b/app/components/article/ArticleFeed.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { type Article } from "~/schemas/article";
 import type { ViewMode } from "../layout/ViewToggle";
 import { ArticleList } from "./ArticleList";
@@ -11,6 +12,7 @@ interface ArticleFeedProps {
   onThumbsDown?: (articleId: string, value: boolean) => Promise<void>;
   onMarkAsRead?: (articleId: string) => Promise<void>;
   emptyMessage?: string;
+  emptyState?: ReactNode;
 }
 
 export function ArticleFeed({ viewMode, ...props }: ArticleFeedProps) {

--- a/app/components/article/ArticleInfo.tsx
+++ b/app/components/article/ArticleInfo.tsx
@@ -94,7 +94,7 @@ export function ArticleInfo({
             href={article.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-5 py-2.5 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-lg font-medium hover:bg-accent-hover dark:hover:bg-teal-300 transition-colors"
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-accent dark:bg-accent-dark text-white rounded-lg font-medium hover:bg-accent-hover dark:hover:bg-accent-dark-hover transition-colors"
           >
             Read Article
             <ExternalLinkIcon className="w-4 h-4" />

--- a/app/components/article/ArticleInfo.tsx
+++ b/app/components/article/ArticleInfo.tsx
@@ -33,7 +33,7 @@ export function ArticleInfo({
   const haveRead = article.have_read ?? false;
 
   return (
-    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden">
+    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-md shadow-stone-300/60 overflow-hidden dark:border dark:border-slate-700 dark:shadow-xl dark:shadow-black/40">
       {/* Source header strip - like the card */}
       <div
         className={`h-14 px-6 flex items-center justify-between ${getCategoryHeaderColor(article.category)}`}

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -102,7 +102,7 @@ export function ArticleRow({
   }, []);
 
   return (
-    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden">
+    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow shadow-stone-300/50 overflow-hidden dark:border dark:border-slate-700/70 dark:shadow-lg dark:shadow-black/30">
       {/* Source header strip */}
       <div
         className={`h-10 px-4 flex items-center justify-between ${getCategoryHeaderColor(article.category)}`}

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -193,10 +193,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsUp}
           disabled={isUpdating}
-          className={`flex items-center gap-1 px-2 py-1 rounded text-sm hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors ${
+          className={`flex items-center gap-1 px-2 py-1 rounded-full text-sm transition-colors ${
             thumbsUp
-              ? "text-green-600 dark:text-green-400"
-              : "text-slate-500 dark:text-slate-400"
+              ? "text-green-600 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/50 dark:ring-green-400/50"
+              : "text-slate-500 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
           aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
         >
@@ -210,10 +210,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsDown}
           disabled={isUpdating}
-          className={`flex items-center gap-1 px-2 py-1 rounded text-sm hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors ${
+          className={`flex items-center gap-1 px-2 py-1 rounded-full text-sm transition-colors ${
             thumbsDown
-              ? "text-red-600 dark:text-red-400"
-              : "text-slate-500 dark:text-slate-400"
+              ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/50 dark:ring-red-400/50"
+              : "text-slate-500 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
           aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
         >
@@ -234,7 +234,7 @@ export function ArticleRow({
             onClick={() => handleSectionToggle("summary")}
             className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
               expandedSection === "summary"
-                ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+                ? "bg-accent text-white dark:bg-accent-dark"
                 : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
@@ -247,7 +247,7 @@ export function ArticleRow({
             onClick={() => handleSectionToggle("key_points")}
             className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
               expandedSection === "key_points"
-                ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+                ? "bg-accent text-white dark:bg-accent-dark"
                 : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
@@ -260,7 +260,7 @@ export function ArticleRow({
             onClick={() => handleSectionToggle("implication")}
             className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
               expandedSection === "implication"
-                ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+                ? "bg-accent text-white dark:bg-accent-dark"
                 : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
@@ -272,7 +272,7 @@ export function ArticleRow({
           onClick={() => handleSectionToggle("similar")}
           className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
             expandedSection === "similar"
-              ? "bg-accent text-white dark:bg-teal-400 dark:text-slate-900"
+              ? "bg-accent text-white dark:bg-accent-dark"
               : "text-slate-600 dark:text-slate-400 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
         >

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -116,7 +116,7 @@ export function ArticleRow({
               {article.category}
             </span>
           )}
-          {isVideoSource(article.source) && <PlayIcon className="w-5 h-5" />}
+          {isVideoSource(article.source) && <PlayIcon className="w-4 h-4" />}
           {haveRead && (
             <span title="Read">
               <CheckCircleIcon className="w-4 h-4 text-green-600 dark:text-green-300" />
@@ -143,6 +143,7 @@ export function ArticleRow({
                 <ThumbnailPlaceholder
                   source={article.source}
                   className="h-full w-full"
+                  iconClassName="w-7 h-7"
                 />
               )}
             </div>
@@ -154,7 +155,7 @@ export function ArticleRow({
                 onClick={handleMarkAsRead}
                 className="group block"
               >
-                <h3 className="font-medium text-slate-900 dark:text-slate-100 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors">
+                <h3 className="font-medium text-slate-900 dark:text-slate-100 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors line-clamp-3">
                   {article.title}
                 </h3>
               </a>
@@ -178,7 +179,7 @@ export function ArticleRow({
           <div className="min-w-0 md:col-span-3">
             <p
               ref={summaryRef}
-              className="text-sm text-slate-600 dark:text-slate-400 line-clamp-4"
+              className="text-sm text-slate-600 dark:text-slate-400 line-clamp-4 max-w-prose"
             >
               {article.summary}
             </p>

--- a/app/components/article/LoadingCard.tsx
+++ b/app/components/article/LoadingCard.tsx
@@ -1,8 +1,11 @@
 export function LoadingCard() {
   return (
     <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden animate-pulse h-full flex flex-col">
-      {/* Header strip placeholder */}
-      <div className="h-12 bg-stone-300 dark:bg-slate-600 flex-shrink-0" />
+      {/* Header strip placeholder - mirrors the coloured category band */}
+      <div className="h-12 bg-stone-300 dark:bg-slate-700 border-l-4 border-stone-400 dark:border-slate-600 flex-shrink-0" />
+
+      {/* Thumbnail block - mirrors the aspect-video thumbnail */}
+      <div className="aspect-video w-full bg-stone-100 dark:bg-stone-800" />
 
       {/* Content */}
       <div className="p-4 flex flex-col flex-grow">

--- a/app/components/article/LoadingRow.tsx
+++ b/app/components/article/LoadingRow.tsx
@@ -1,22 +1,25 @@
 export function LoadingRow() {
   return (
     <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden animate-pulse">
-      {/* Header strip placeholder */}
-      <div className="h-10 bg-stone-300 dark:bg-slate-600" />
+      {/* Header strip placeholder - mirrors the coloured category band */}
+      <div className="h-10 bg-stone-300 dark:bg-slate-700 border-l-4 border-stone-400 dark:border-slate-600" />
 
-      {/* Two-column content placeholder */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
-        {/* Left: title/author */}
-        <div>
-          <div className="space-y-2 mb-2">
-            <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-full" />
-            <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-3/4" />
+      {/* Two-column content placeholder (2fr / 3fr like the row) */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 p-4">
+        {/* Left: thumbnail + title/author */}
+        <div className="md:col-span-2 flex gap-3">
+          <div className="hidden sm:block flex-shrink-0 w-16 h-16 rounded bg-stone-100 dark:bg-stone-800" />
+          <div className="min-w-0 flex-1">
+            <div className="space-y-2 mb-2">
+              <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-full" />
+              <div className="h-4 bg-stone-200 dark:bg-slate-700 rounded w-3/4" />
+            </div>
+            <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-1/2" />
           </div>
-          <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-1/2" />
         </div>
 
         {/* Right: summary */}
-        <div className="space-y-2">
+        <div className="md:col-span-3 space-y-2">
           <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-full" />
           <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-full" />
           <div className="h-3 bg-stone-200 dark:bg-slate-700 rounded w-2/3" />

--- a/app/components/article/ThumbnailPlaceholder.tsx
+++ b/app/components/article/ThumbnailPlaceholder.tsx
@@ -3,19 +3,21 @@ import { getSourcePlaceholderIcon } from "~/constants/sourceIcons";
 interface ThumbnailPlaceholderProps {
   source: string;
   className?: string;
+  iconClassName?: string;
 }
 
 export function ThumbnailPlaceholder({
   source,
   className = "",
+  iconClassName = "w-10 h-10",
 }: ThumbnailPlaceholderProps) {
   const Icon = getSourcePlaceholderIcon(source);
   return (
     <div
-      className={`flex items-center justify-center bg-stone-100 dark:bg-slate-700 ${className}`}
+      className={`flex items-center justify-center bg-stone-100 dark:bg-stone-800 ${className}`}
       data-testid="thumbnail-placeholder"
     >
-      <Icon className="w-10 h-10 text-stone-400 dark:text-slate-500" />
+      <Icon className={`${iconClassName} text-stone-400 dark:text-stone-600`} />
     </div>
   );
 }

--- a/app/components/chat/ChatArticleCard.tsx
+++ b/app/components/chat/ChatArticleCard.tsx
@@ -17,7 +17,7 @@ export function ChatArticleCard({
       onClick={
         onArticleClick ? () => onArticleClick(article.hash_id) : undefined
       }
-      className="block rounded-lg border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-slate-700 p-3 hover:border-accent dark:hover:border-teal-400 transition-colors"
+      className="block rounded-lg border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-slate-700 p-3 hover:border-accent dark:hover:border-accent-dark-fg transition-colors"
     >
       <h4 className="text-sm font-medium text-slate-900 dark:text-slate-100 line-clamp-2">
         {article.title}

--- a/app/components/chat/ChatInput.tsx
+++ b/app/components/chat/ChatInput.tsx
@@ -68,7 +68,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
           <button
             type="submit"
             disabled={isLoading || !value.trim()}
-            className="rounded-lg bg-accent dark:bg-teal-400 px-4 py-3 text-sm font-medium text-white dark:text-slate-900 hover:bg-accent-hover dark:hover:bg-teal-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="rounded-lg bg-accent dark:bg-accent-dark px-4 py-3 text-sm font-medium text-white hover:bg-accent-hover dark:hover:bg-accent-dark-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {isLoading ? "..." : "Send"}
           </button>

--- a/app/components/chat/ChatMessage.tsx
+++ b/app/components/chat/ChatMessage.tsx
@@ -105,7 +105,7 @@ function ChatMarkdown({
                   ? () => onArticleClick(hashId)
                   : undefined
               }
-              className="text-teal-700 dark:text-teal-400 underline hover:text-teal-900 dark:hover:text-teal-300"
+              className="text-teal-700 dark:text-accent-dark-fg underline hover:text-teal-900 dark:hover:text-accent-dark-fg-hover"
             >
               {children}
             </a>
@@ -330,7 +330,7 @@ export function ChatMessage({
       <div
         className={`max-w-[85%] rounded-lg px-4 py-3 ${
           isUser
-            ? "bg-accent text-white dark:bg-teal-900"
+            ? "bg-accent text-white dark:bg-accent-dark"
             : "bg-stone-50 dark:bg-slate-700 text-slate-900 dark:text-slate-100 border border-stone-200 dark:border-slate-600"
         }`}
       >

--- a/app/components/feedback/EmptyState.test.tsx
+++ b/app/components/feedback/EmptyState.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { EmptyState } from "./EmptyState";
+import { InboxIcon } from "~/components/layout/Icons";
+
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(
+      <MemoryRouter>
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No articles yet"
+          description="New research will appear here."
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("No articles yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("New research will appear here.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders action button when action.to is provided", () => {
+    render(
+      <MemoryRouter>
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No articles"
+          action={{ label: "Browse feed", to: "/" }}
+        />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("button", { name: "Browse feed" })
+    ).toBeInTheDocument();
+  });
+
+  it("fires onClick when action.onClick button is clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <MemoryRouter>
+        <EmptyState
+          icon={<InboxIcon />}
+          title="No articles"
+          action={{ label: "Refresh", onClick }}
+        />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders icon as svg", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <EmptyState icon={<InboxIcon />} title="No articles" />
+      </MemoryRouter>
+    );
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/app/components/feedback/EmptyState.tsx
+++ b/app/components/feedback/EmptyState.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Link } from "@remix-run/react";
+import { Button } from "~/components/ui/Button";
+
+export interface EmptyStateAction {
+  label: string;
+  to?: string;
+  onClick?: () => void;
+}
+
+export interface EmptyStateProps {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: EmptyStateAction;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center text-center px-4 py-16"
+    >
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-stone-200/70 dark:bg-slate-800 [&>svg]:h-8 [&>svg]:w-8 [&>svg]:text-stone-500 dark:[&>svg]:text-slate-400">
+        {icon}
+      </div>
+      <h2 className="text-lg font-semibold text-brand-dark dark:text-brand-light">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-2 max-w-sm text-sm text-slate-600 dark:text-slate-400">
+          {description}
+        </p>
+      )}
+      {action && (
+        <div className="mt-6">
+          {action.to ? (
+            <Link to={action.to}>
+              <Button variant="primary" type="button">
+                {action.label}
+              </Button>
+            </Link>
+          ) : action.onClick ? (
+            <Button variant="primary" type="button" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/feedback/ErrorState.test.tsx
+++ b/app/components/feedback/ErrorState.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ErrorState } from "./ErrorState";
+
+describe("ErrorState", () => {
+  it("renders default title and description", () => {
+    render(
+      <MemoryRouter>
+        <ErrorState />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText("We couldn’t load this content. Please try again.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders custom title and description", () => {
+    render(
+      <MemoryRouter>
+        <ErrorState title="Custom error" description="Custom description" />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Custom error")).toBeInTheDocument();
+    expect(screen.getByText("Custom description")).toBeInTheDocument();
+  });
+
+  it("fires onRetry when retry button is clicked", () => {
+    const onRetry = vi.fn();
+    render(
+      <MemoryRouter>
+        <ErrorState onRetry={onRetry} />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("renders back link when backTo is provided", () => {
+    render(
+      <MemoryRouter>
+        <ErrorState backTo="/" backLabel="Go home" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("button", { name: "Go home" })).toBeInTheDocument();
+  });
+});

--- a/app/components/feedback/ErrorState.tsx
+++ b/app/components/feedback/ErrorState.tsx
@@ -1,0 +1,56 @@
+import { Link } from "@remix-run/react";
+import { Button } from "~/components/ui/Button";
+import { ExclamationTriangleIcon } from "~/components/layout/Icons";
+
+export interface ErrorStateProps {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+  backTo?: string;
+  backLabel?: string;
+}
+
+export function ErrorState({
+  title = "Something went wrong",
+  description = "We couldn’t load this content. Please try again.",
+  onRetry,
+  retryLabel = "Try again",
+  backTo,
+  backLabel = "Back to feed",
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center text-center px-4 py-16"
+    >
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/25 [&>svg]:h-8 [&>svg]:w-8 [&>svg]:text-red-500 dark:[&>svg]:text-red-400">
+        <ExclamationTriangleIcon />
+      </div>
+      <h2 className="text-lg font-semibold text-brand-dark dark:text-brand-light">
+        {title}
+      </h2>
+      {description && (
+        <p className="mt-2 max-w-sm text-sm text-slate-600 dark:text-slate-400">
+          {description}
+        </p>
+      )}
+      {(onRetry || backTo) && (
+        <div className="mt-6 flex items-center gap-3">
+          {onRetry && (
+            <Button variant="primary" type="button" onClick={onRetry}>
+              {retryLabel}
+            </Button>
+          )}
+          {backTo && (
+            <Link to={backTo}>
+              <Button variant="outline" type="button">
+                {backLabel}
+              </Button>
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/feedback/LoginGate.test.tsx
+++ b/app/components/feedback/LoginGate.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { LoginGate } from "./LoginGate";
+
+describe("LoginGate", () => {
+  it("renders title and description", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate title="Log in required" description="You need to log in." />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Log in required")).toBeInTheDocument();
+    expect(screen.getByText("You need to log in.")).toBeInTheDocument();
+  });
+
+  it("renders default CTA linking to /auth/login", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate title="Log in" description="Please log in." />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole("link", { name: "Log In" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/auth/login");
+  });
+
+  it("renders custom ctaLabel", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate
+          title="Log in"
+          description="Please log in."
+          ctaLabel="Sign In"
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Sign In" })).toBeInTheDocument();
+  });
+
+  it("renders custom to path", () => {
+    render(
+      <MemoryRouter>
+        <LoginGate title="Log in" description="Please log in." to="/login" />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole("link", { name: "Log In" });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});

--- a/app/components/feedback/LoginGate.tsx
+++ b/app/components/feedback/LoginGate.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Link } from "@remix-run/react";
+import { Button } from "~/components/ui/Button";
+import { LockClosedIcon } from "~/components/layout/Icons";
+
+export interface LoginGateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  to?: string;
+}
+
+export function LoginGate({
+  icon,
+  title,
+  description,
+  ctaLabel = "Log In",
+  to = "/auth/login",
+}: LoginGateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center text-center px-4 py-16">
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-accent-light dark:bg-accent-dark/25 [&>svg]:h-8 [&>svg]:w-8 [&>svg]:text-accent dark:[&>svg]:text-accent-dark-fg">
+        {icon ?? <LockClosedIcon />}
+      </div>
+      <h2 className="text-lg font-semibold text-brand-dark dark:text-brand-light">
+        {title}
+      </h2>
+      <p className="mt-2 max-w-sm text-sm text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+      <div className="mt-6">
+        <Link to={to}>
+          <Button variant="primary" type="button">
+            {ctaLabel}
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/components/feedback/index.ts
+++ b/app/components/feedback/index.ts
@@ -1,0 +1,6 @@
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps, EmptyStateAction } from "./EmptyState";
+export { ErrorState } from "./ErrorState";
+export type { ErrorStateProps } from "./ErrorState";
+export { LoginGate } from "./LoginGate";
+export type { LoginGateProps } from "./LoginGate";

--- a/app/components/layout/HeroHeader.tsx
+++ b/app/components/layout/HeroHeader.tsx
@@ -22,7 +22,7 @@ export function HeroHeader({
 
   return (
     <section className="text-center pt-20 pb-8 px-4 bg-brand-bg dark:bg-brand-bg-dark">
-      <h1 className="text-3xl md:text-4xl lg:text-5xl font-light italic text-slate-900 dark:text-slate-100 mb-8 font-serif">
+      <h1 className="text-3xl md:text-4xl lg:text-5xl font-light italic text-slate-900 dark:text-slate-200 mb-8 font-serif">
         Your personalised AI Safety research feed.
       </h1>
       {showSearch && onSearchChange && onSearch && (

--- a/app/components/layout/Icons.tsx
+++ b/app/components/layout/Icons.tsx
@@ -92,7 +92,7 @@ export function CheckCircleIcon(props: IconProps) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={2}
+      strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
       {...props}

--- a/app/components/layout/Icons.tsx
+++ b/app/components/layout/Icons.tsx
@@ -392,3 +392,79 @@ export function CodeBracketIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function InboxIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"
+      />
+    </svg>
+  );
+}
+
+export function ExclamationTriangleIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+      />
+    </svg>
+  );
+}
+
+export function LockClosedIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+      />
+    </svg>
+  );
+}
+
+export function SparklesIcon(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z"
+      />
+    </svg>
+  );
+}

--- a/app/components/layout/SearchBar.tsx
+++ b/app/components/layout/SearchBar.tsx
@@ -60,7 +60,7 @@ export function SearchBar({
         onChange={e => setLocalValue(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className="w-full px-6 py-4 pr-14 text-base text-slate-900 dark:text-slate-100 bg-stone-50 dark:bg-slate-800 border border-stone-200 dark:border-slate-600 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 focus:border-transparent placeholder:text-stone-500 dark:placeholder:text-slate-400"
+        className="w-full px-6 py-4 pr-14 text-base text-slate-900 dark:text-slate-100 bg-stone-50 dark:bg-slate-800 border border-stone-200 dark:border-slate-600 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-accent-dark-fg focus:border-transparent placeholder:text-stone-500 dark:placeholder:text-slate-400"
         aria-label="Search articles"
       />
       <button

--- a/app/components/layout/ViewToggle.tsx
+++ b/app/components/layout/ViewToggle.tsx
@@ -9,13 +9,13 @@ interface ViewToggleProps {
 
 export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
   return (
-    <div className="flex flex-shrink-0 items-center gap-1 rounded-md border border-stone-200 dark:border-slate-700 p-0.5">
+    <div className="flex flex-shrink-0 items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-700 p-1">
       <button
         type="button"
         onClick={() => onChange("list")}
         className={`rounded p-1.5 transition-colors ${
           viewMode === "list"
-            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-accent-dark-fg"
+            ? "bg-white text-accent shadow-sm ring-1 ring-accent/40 dark:bg-slate-700 dark:text-accent-dark-fg dark:ring-accent-dark-fg/40"
             : "text-stone-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
         }`}
         aria-label="List view"
@@ -28,7 +28,7 @@ export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
         onClick={() => onChange("grid")}
         className={`rounded p-1.5 transition-colors ${
           viewMode === "grid"
-            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-accent-dark-fg"
+            ? "bg-white text-accent shadow-sm ring-1 ring-accent/40 dark:bg-slate-700 dark:text-accent-dark-fg dark:ring-accent-dark-fg/40"
             : "text-stone-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
         }`}
         aria-label="Grid view"

--- a/app/components/layout/ViewToggle.tsx
+++ b/app/components/layout/ViewToggle.tsx
@@ -15,7 +15,7 @@ export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
         onClick={() => onChange("list")}
         className={`rounded p-1.5 transition-colors ${
           viewMode === "list"
-            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-teal-400"
+            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-accent-dark-fg"
             : "text-stone-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
         }`}
         aria-label="List view"
@@ -28,7 +28,7 @@ export function ViewToggle({ viewMode, onChange }: ViewToggleProps) {
         onClick={() => onChange("grid")}
         className={`rounded p-1.5 transition-colors ${
           viewMode === "grid"
-            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-teal-400"
+            ? "bg-teal-50 text-accent dark:bg-teal-900 dark:text-accent-dark-fg"
             : "text-stone-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
         }`}
         aria-label="Grid view"

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -9,9 +9,9 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    "bg-accent dark:bg-teal-400 text-white dark:text-slate-900 hover:bg-accent-hover dark:hover:bg-teal-300 border border-accent dark:border-teal-400",
+    "bg-accent dark:bg-accent-dark text-white hover:bg-accent-hover dark:hover:bg-accent-dark-hover border border-accent dark:border-accent-dark",
   outline:
-    "bg-transparent text-brand-dark dark:text-teal-400 hover:bg-stone-100 dark:hover:bg-slate-700 border border-stone-300 dark:border-slate-600",
+    "bg-transparent text-brand-dark dark:text-accent-dark-fg hover:bg-stone-100 dark:hover:bg-slate-700 border border-stone-300 dark:border-slate-600",
 };
 
 export function Button({
@@ -22,7 +22,7 @@ export function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent dark:focus:ring-teal-400 dark:focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed ${variantClasses[variant]} ${className}`}
+      className={`px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent dark:focus:ring-accent-dark-fg dark:focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed ${variantClasses[variant]} ${className}`}
       {...props}
     >
       {children}

--- a/app/components/ui/Tabs.tsx
+++ b/app/components/ui/Tabs.tsx
@@ -41,7 +41,7 @@ export function Tabs({ tabs, activeTab, onBeforeNavigate }: TabsProps) {
           >
             {tab.label}
             {isActive && (
-              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent dark:bg-teal-400" />
+              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent dark:bg-accent-dark-fg" />
             )}
           </Link>
         );

--- a/app/constants/sources.ts
+++ b/app/constants/sources.ts
@@ -1,30 +1,30 @@
 // Category-based header colors for card/row header backgrounds
-// Dark backgrounds with white text; slightly lighter in dark mode for contrast
+// Tint + left-border in both light and dark schemes; dark uses a deep tint with colored border and text
 const CATEGORY_HEADER_COLORS: Record<string, string> = {
   Interpretability:
-    "bg-teal-50 border-l-4 border-l-teal-600 text-teal-900 dark:bg-teal-700 dark:border-l-0 dark:text-white",
+    "bg-teal-50 border-l-4 border-l-teal-600 text-teal-900 dark:bg-teal-950/40 dark:border-l-teal-800 dark:text-teal-100",
   "Safety Techniques":
-    "bg-blue-50 border-l-4 border-l-blue-600 text-blue-900 dark:bg-blue-700 dark:border-l-0 dark:text-white",
+    "bg-blue-50 border-l-4 border-l-blue-600 text-blue-900 dark:bg-blue-950/40 dark:border-l-blue-800 dark:text-blue-100",
   "Governance & Policy":
-    "bg-indigo-50 border-l-4 border-l-indigo-600 text-indigo-900 dark:bg-indigo-700 dark:border-l-0 dark:text-white",
+    "bg-indigo-50 border-l-4 border-l-indigo-600 text-indigo-900 dark:bg-indigo-950/40 dark:border-l-indigo-800 dark:text-indigo-100",
   "Deception & Misalignment":
-    "bg-red-50 border-l-4 border-l-red-600 text-red-900 dark:bg-red-700 dark:border-l-0 dark:text-white",
+    "bg-red-50 border-l-4 border-l-red-600 text-red-900 dark:bg-red-950/40 dark:border-l-red-800 dark:text-red-100",
   "AI Capabilities & Behavior":
-    "bg-amber-50 border-l-4 border-l-amber-600 text-amber-900 dark:bg-amber-700 dark:border-l-0 dark:text-white",
+    "bg-amber-50 border-l-4 border-l-amber-600 text-amber-900 dark:bg-amber-950/40 dark:border-l-amber-800 dark:text-amber-100",
   "Risks & Strategy":
-    "bg-rose-50 border-l-4 border-l-rose-600 text-rose-900 dark:bg-rose-700 dark:border-l-0 dark:text-white",
+    "bg-rose-50 border-l-4 border-l-rose-600 text-rose-900 dark:bg-rose-950/40 dark:border-l-rose-800 dark:text-rose-100",
   Forecasting:
-    "bg-cyan-50 border-l-4 border-l-cyan-600 text-cyan-900 dark:bg-cyan-700 dark:border-l-0 dark:text-white",
+    "bg-cyan-50 border-l-4 border-l-cyan-600 text-cyan-900 dark:bg-cyan-950/40 dark:border-l-cyan-800 dark:text-cyan-100",
   "AI & Society":
-    "bg-purple-50 border-l-4 border-l-purple-600 text-purple-900 dark:bg-purple-700 dark:border-l-0 dark:text-white",
+    "bg-purple-50 border-l-4 border-l-purple-600 text-purple-900 dark:bg-purple-950/40 dark:border-l-purple-800 dark:text-purple-100",
   "Field Building":
-    "bg-green-50 border-l-4 border-l-green-600 text-green-900 dark:bg-green-700 dark:border-l-0 dark:text-white",
+    "bg-green-50 border-l-4 border-l-green-600 text-green-900 dark:bg-green-950/40 dark:border-l-green-800 dark:text-green-100",
   Other:
-    "bg-stone-100 border-l-4 border-l-stone-500 text-stone-800 dark:bg-slate-600 dark:border-l-0 dark:text-white",
+    "bg-stone-100 border-l-4 border-l-stone-500 text-stone-800 dark:bg-slate-800/60 dark:border-l-slate-600 dark:text-slate-200",
 };
 
 const DEFAULT_HEADER_COLOR =
-  "bg-stone-100 border-l-4 border-l-stone-500 text-stone-800 dark:bg-slate-600 dark:border-l-0 dark:text-white";
+  "bg-stone-100 border-l-4 border-l-stone-500 text-stone-800 dark:bg-slate-800/60 dark:border-l-slate-600 dark:text-slate-200";
 
 export function getCategoryHeaderColor(
   category: string | null | undefined

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,7 @@ function NavigationProgressBar() {
 
   return (
     <div className="fixed top-0 left-0 right-0 z-50 h-1 bg-stone-200 dark:bg-slate-700 overflow-hidden">
-      <div className="h-full bg-accent dark:bg-teal-400 animate-progress-bar" />
+      <div className="h-full bg-accent dark:bg-accent-dark animate-progress-bar" />
     </div>
   );
 }
@@ -174,13 +174,13 @@ export function ErrorBoundary() {
             {statusCode}
           </p>
         )}
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-200 mb-4">
           {title}
         </h1>
         <p className="text-slate-600 dark:text-slate-400 mb-8">{message}</p>
         <Link
           to="/"
-          className="inline-block px-6 py-3 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-lg font-medium hover:opacity-90 transition-opacity"
+          className="inline-block px-6 py-3 bg-accent dark:bg-accent-dark text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
         >
           Back to Home
         </Link>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -148,7 +148,7 @@ export function ErrorBoundary() {
     statusCode = error.status;
     if (error.status === 404) {
       title = "Page not found";
-      message = "The page you're looking for doesn't exist.";
+      message = "The page you’re looking for doesn’t exist.";
     } else if (error.status === 500) {
       title = "Server error";
       message = "Something went wrong on our end. Please try again later.";

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,9 @@
 import { useState, useCallback } from "react";
-import { useSearchParams, useLoaderData } from "@remix-run/react";
+import {
+  useSearchParams,
+  useLoaderData,
+  useRevalidator,
+} from "@remix-run/react";
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 import { TopBar } from "~/components/layout/TopBar";
@@ -14,6 +18,8 @@ import { useInfiniteScroll } from "~/hooks/useInfiniteScroll";
 import { useViewPreference } from "~/hooks/useViewPreference";
 import { createAuthenticatedFetch } from "~/server/auth.server";
 import { parseArticlesResponse, type Article } from "~/schemas/article";
+import { EmptyState, ErrorState } from "~/components/feedback";
+import { SearchIcon, InboxIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -119,11 +125,18 @@ export default function Index() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useArticles(searchQuery, { initialArticles });
 
   // Combine loader and fetch errors
   const error = loaderError ?? fetchError?.message;
+
+  const revalidator = useRevalidator();
+  const handleRetry = useCallback(() => {
+    revalidator.revalidate();
+    refetch();
+  }, [revalidator, refetch]);
 
   // Shared feedback handlers with optimistic updates
   const { handleThumbsUp, handleThumbsDown, handleMarkAsRead } =
@@ -175,9 +188,7 @@ export default function Index() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {error && articles.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} />
           ) : (
             <>
               <ArticleFeed
@@ -191,6 +202,25 @@ export default function Index() {
                   searchQuery
                     ? `No articles found for "${searchQuery}"`
                     : "No articles found"
+                }
+                emptyState={
+                  searchQuery ? (
+                    <EmptyState
+                      icon={<SearchIcon />}
+                      title={`No results for "${searchQuery}"`}
+                      description="Try a different keyword, or clear the search to see the full feed."
+                      action={{
+                        label: "Clear search",
+                        onClick: () => handleSearch(""),
+                      }}
+                    />
+                  ) : (
+                    <EmptyState
+                      icon={<InboxIcon />}
+                      title="No articles yet"
+                      description="New AI-safety research will appear here as it's published."
+                    />
+                  )
                 }
               />
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -232,7 +232,7 @@ export default function Index() {
               {/* End of results indicator */}
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -127,7 +127,7 @@ export default function ArticleDetails() {
         {/* Analysis Section */}
         {article.summary && (
           <div className="max-w-4xl mx-auto px-6 pb-8">
-            <div className="bg-stone-50 dark:bg-slate-800 rounded-lg p-6 shadow-sm">
+            <div className="bg-stone-50 dark:bg-slate-800/60 rounded-lg p-6 shadow-sm dark:shadow-none dark:border dark:border-slate-700/50">
               <div className="flex items-center gap-3 mb-4">
                 <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
                   Analysis

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -129,7 +129,7 @@ export default function ArticleDetails() {
           <div className="max-w-4xl mx-auto px-6 pb-8">
             <div className="bg-stone-50 dark:bg-slate-800 rounded-lg p-6 shadow-sm">
               <div className="flex items-center gap-3 mb-4">
-                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
                   Analysis
                 </h2>
                 {article.category && (
@@ -139,16 +139,16 @@ export default function ArticleDetails() {
                 )}
               </div>
 
-              <p className="text-slate-700 dark:text-slate-300 mb-4">
+              <p className="text-slate-700 dark:text-slate-300 mb-4 max-w-prose">
                 {article.summary}
               </p>
 
               {article.key_points && article.key_points.length > 0 && (
                 <div className="mb-4">
-                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+                  <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
                     Key Points
                   </h3>
-                  <ul className="list-disc list-inside space-y-1 text-slate-700 dark:text-slate-300">
+                  <ul className="list-disc list-inside space-y-1 text-slate-700 dark:text-slate-300 max-w-prose">
                     {article.key_points.map((point, i) => (
                       <li key={i}>{point}</li>
                     ))}
@@ -158,10 +158,10 @@ export default function ArticleDetails() {
 
               {article.implication && (
                 <div>
-                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+                  <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
                     Implications for AI Alignment
                   </h3>
-                  <p className="text-slate-700 dark:text-slate-300">
+                  <p className="text-slate-700 dark:text-slate-300 max-w-prose">
                     {article.implication}
                   </p>
                 </div>
@@ -173,7 +173,7 @@ export default function ArticleDetails() {
         {/* Similar Articles Section */}
         {similarArticles.length > 0 && (
           <div className="max-w-7xl mx-auto px-6 py-8">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-200 mb-6">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-200 mb-6">
               Similar Articles
             </h2>
             <ArticleGrid
@@ -209,7 +209,7 @@ export function ErrorBoundary() {
               </h2>
               <p className="text-slate-600 dark:text-slate-400 text-center max-w-md">
                 {error.status === 404
-                  ? "The article you're looking for doesn't exist or may have been removed."
+                  ? "The article you’re looking for doesn’t exist or may have been removed."
                   : error.data ||
                     "Something went wrong while loading this article."}
               </p>

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -173,7 +173,7 @@ export default function ArticleDetails() {
         {/* Similar Articles Section */}
         {similarArticles.length > 0 && (
           <div className="max-w-7xl mx-auto px-6 py-8">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100 mb-6">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-200 mb-6">
               Similar Articles
             </h2>
             <ArticleGrid
@@ -202,7 +202,7 @@ export function ErrorBoundary() {
         <div className="flex flex-col items-center justify-center min-h-[50vh] px-6">
           {isRouteErrorResponse(error) ? (
             <>
-              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-200 mb-4">
                 {error.status === 404
                   ? "Article Not Found"
                   : `Error ${error.status}`}
@@ -216,7 +216,7 @@ export function ErrorBoundary() {
             </>
           ) : (
             <>
-              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">
+              <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-200 mb-4">
                 Something went wrong
               </h2>
               <p className="text-slate-600 dark:text-slate-400 text-center max-w-md">
@@ -226,7 +226,7 @@ export function ErrorBoundary() {
           )}
           <Link
             to="/"
-            className="mt-8 px-6 py-2 bg-accent dark:bg-teal-400 text-white dark:text-slate-900 rounded-md hover:bg-accent-hover dark:hover:bg-teal-300 transition-colors"
+            className="mt-8 px-6 py-2 bg-accent dark:bg-accent-dark text-white rounded-md hover:bg-accent-hover dark:hover:bg-accent-dark-hover transition-colors"
           >
             Return to home
           </Link>

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -1,10 +1,9 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { ChatPanel } from "~/components/chat/ChatPanel";
 import { getServerAuthContext } from "~/server/auth.server";
@@ -13,6 +12,8 @@ import {
   type Conversation,
   type UserId,
 } from "~/server/chat.server";
+import { LoginGate } from "~/components/feedback";
+import { ChatBubbleIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -76,16 +77,11 @@ export default function Chat() {
         {/* Content */}
         {!isAuthenticated ? (
           <div className="max-w-7xl mx-auto">
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to chat with the AI research assistant.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<ChatBubbleIcon />}
+              title="Chat with the research assistant"
+              description="Log in to ask questions about alignment research and get cited answers."
+            />
           </div>
         ) : (
           <div className="max-w-7xl w-full mx-auto px-6 mt-4 mb-4 flex-1 min-h-0">

--- a/app/routes/disliked.tsx
+++ b/app/routes/disliked.tsx
@@ -111,7 +111,7 @@ export default function Disliked() {
                 onThumbsUp={handleThumbsUp}
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
-                emptyMessage="No disliked articles. You haven't disliked anything yet."
+                emptyMessage="No disliked articles. You haven’t disliked anything yet."
                 emptyState={
                   <EmptyState
                     icon={<ThumbsDownIcon />}
@@ -128,7 +128,7 @@ export default function Disliked() {
 
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/routes/disliked.tsx
+++ b/app/routes/disliked.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useUserArticles } from "~/hooks/useUserArticles";
@@ -15,6 +14,8 @@ import {
   fetchArticlesFromApi,
   createPaginationParams,
 } from "~/server/articles.server";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { ThumbsDownIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -53,6 +54,7 @@ export default function Disliked() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useUserArticles("disliked", { initialArticles });
 
@@ -66,9 +68,14 @@ export default function Disliked() {
   });
 
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
 
   const showLoginPrompt = !isAuthenticated;
   const error = loaderError ?? fetchError?.message;
+  const handleRetry = () => {
+    revalidator.revalidate();
+    refetch();
+  };
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -88,20 +95,13 @@ export default function Disliked() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see your disliked articles.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Disliked Articles
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<ThumbsDownIcon />}
+              title="Your disliked articles"
+              description="Log in to track what you've set aside and tune your feed."
+            />
           ) : error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} backTo="/" />
           ) : (
             <>
               <ArticleFeed
@@ -112,6 +112,14 @@ export default function Disliked() {
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
                 emptyMessage="No disliked articles. You haven't disliked anything yet."
+                emptyState={
+                  <EmptyState
+                    icon={<ThumbsDownIcon />}
+                    title="Nothing disliked"
+                    description="Articles you dislike are hidden from your feed and listed here."
+                    action={{ label: "Browse the feed", to: "/" }}
+                  />
+                }
               />
 
               {hasMore && (

--- a/app/routes/liked.tsx
+++ b/app/routes/liked.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useUserArticles } from "~/hooks/useUserArticles";
@@ -15,6 +14,8 @@ import {
   fetchArticlesFromApi,
   createPaginationParams,
 } from "~/server/articles.server";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { ThumbsUpIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -53,6 +54,7 @@ export default function Liked() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useUserArticles("liked", { initialArticles });
 
@@ -66,9 +68,14 @@ export default function Liked() {
   });
 
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
 
   const showLoginPrompt = !isAuthenticated;
   const error = loaderError ?? fetchError?.message;
+  const handleRetry = () => {
+    revalidator.revalidate();
+    refetch();
+  };
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -88,20 +95,13 @@ export default function Liked() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see your liked articles.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Liked Articles
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<ThumbsUpIcon />}
+              title="Your liked articles"
+              description="Log in to keep a personal library of the research you've liked."
+            />
           ) : error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} backTo="/" />
           ) : (
             <>
               <ArticleFeed
@@ -112,6 +112,14 @@ export default function Liked() {
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
                 emptyMessage="No liked articles yet. Like some articles to see them here!"
+                emptyState={
+                  <EmptyState
+                    icon={<ThumbsUpIcon />}
+                    title="No liked articles yet"
+                    description="Like an article and it'll collect here for easy reference."
+                    action={{ label: "Browse the feed", to: "/" }}
+                  />
+                }
               />
 
               {hasMore && (

--- a/app/routes/liked.tsx
+++ b/app/routes/liked.tsx
@@ -128,7 +128,7 @@ export default function Liked() {
 
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/routes/recommended.tsx
+++ b/app/routes/recommended.tsx
@@ -1,12 +1,12 @@
 import React, { Suspense } from "react";
+import type { ReactNode } from "react";
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData, Await } from "@remix-run/react";
+import { useLoaderData, Await, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle, type ViewMode } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useViewPreference } from "~/hooks/useViewPreference";
@@ -15,6 +15,8 @@ import {
   type FetchArticlesResult,
 } from "~/server/articles.server";
 import { RecommendationsLoading } from "~/components/article/RecommendationsLoading";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { SparklesIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -51,9 +53,11 @@ type LoaderData = {
 function RecommendedContent({
   articlesData,
   viewMode,
+  emptyState,
 }: {
   articlesData: FetchArticlesResult;
   viewMode: ViewMode;
+  emptyState?: ReactNode;
 }) {
   const { handleThumbsUp, handleThumbsDown, handleMarkAsRead } =
     useArticleFeedbackHandlers();
@@ -67,6 +71,7 @@ function RecommendedContent({
       onThumbsDown={handleThumbsDown}
       onMarkAsRead={handleMarkAsRead}
       emptyMessage="No recommendations yet. Like some articles to get personalized suggestions!"
+      emptyState={emptyState}
     />
   );
 }
@@ -74,7 +79,17 @@ function RecommendedContent({
 export default function Recommended() {
   const { isAuthenticated, articlesData } = useLoaderData<LoaderData>();
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
   const showLoginPrompt = !isAuthenticated;
+
+  const emptyState = (
+    <EmptyState
+      icon={<SparklesIcon />}
+      title="No recommendations yet"
+      description="Like a few articles and we'll surface related research here."
+      action={{ label: "Browse the feed", to: "/" }}
+    />
+  );
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -94,27 +109,21 @@ export default function Recommended() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see personalized recommendations based on your
-                interests.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Recommendations
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<SparklesIcon />}
+              title="Personalised recommendations"
+              description="Log in and like a few articles to get research picked for your interests."
+            />
           ) : (
             <Suspense fallback={<RecommendationsLoading />}>
               <Await
                 resolve={articlesData}
                 errorElement={
-                  <div className="flex flex-col items-center justify-center py-16 px-4">
-                    <p className="text-red-600 dark:text-red-400 text-lg">
-                      Failed to load recommendations. Please try again later.
-                    </p>
-                  </div>
+                  <ErrorState
+                    title="Couldn't load recommendations"
+                    description="Something went wrong fetching your picks."
+                    onRetry={() => revalidator.revalidate()}
+                  />
                 }
               >
                 {/* Cast needed: Remix's Await type inference doesn't preserve deferred promise types */}
@@ -123,6 +132,7 @@ export default function Recommended() {
                     <RecommendedContent
                       articlesData={resolved}
                       viewMode={viewMode}
+                      emptyState={emptyState}
                     />
                   )) as (value: unknown) => React.ReactNode
                 }

--- a/app/routes/semantic-search.tsx
+++ b/app/routes/semantic-search.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { MetaFunction } from "@remix-run/cloudflare";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
@@ -10,6 +10,8 @@ import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useViewPreference } from "~/hooks/useViewPreference";
 import { parseArticlesResponse, type Article } from "~/schemas/article";
+import { EmptyState, ErrorState } from "~/components/feedback";
+import { SearchIcon, SparklesIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -40,53 +42,62 @@ export default function SemanticSearch() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
+  const lastQueryRef = useRef("");
 
   const [viewMode, setViewMode] = useViewPreference();
 
   const { handleThumbsUp, handleThumbsDown, handleMarkAsRead } =
     useArticleFeedbackHandlers({ setArticles });
 
+  const runSearch = useCallback(async (query: string) => {
+    setIsLoading(true);
+    setError(null);
+    setHasSearched(true);
+
+    try {
+      const response = await fetch("/api/articles/semantic-search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: query, limit: 20 }),
+      });
+
+      if (!response.ok) {
+        setError("Search failed. Please try again later.");
+        setArticles([]);
+        return;
+      }
+
+      const result = parseArticlesResponse(await response.json());
+
+      if (!result.success) {
+        setError("Failed to parse search results.");
+        setArticles([]);
+        return;
+      }
+
+      setArticles(result.data.data);
+    } catch {
+      setError("Search failed. Please check your connection and try again.");
+      setArticles([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
       const trimmed = text.trim();
       if (!trimmed) return;
-
-      setIsLoading(true);
-      setError(null);
-      setHasSearched(true);
-
-      try {
-        const response = await fetch("/api/articles/semantic-search", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text: trimmed, limit: 20 }),
-        });
-
-        if (!response.ok) {
-          setError("Search failed. Please try again later.");
-          setArticles([]);
-          return;
-        }
-
-        const result = parseArticlesResponse(await response.json());
-
-        if (!result.success) {
-          setError("Failed to parse search results.");
-          setArticles([]);
-          return;
-        }
-
-        setArticles(result.data.data);
-      } catch {
-        setError("Search failed. Please check your connection and try again.");
-        setArticles([]);
-      } finally {
-        setIsLoading(false);
-      }
+      lastQueryRef.current = trimmed;
+      runSearch(trimmed);
     },
-    [text]
+    [text, runSearch]
   );
+
+  const retry = useCallback(() => {
+    if (lastQueryRef.current) runSearch(lastQueryRef.current);
+  }, [runSearch]);
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -126,9 +137,7 @@ export default function SemanticSearch() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={retry} />
           ) : (
             <ArticleFeed
               viewMode={viewMode}
@@ -141,6 +150,21 @@ export default function SemanticSearch() {
                 hasSearched
                   ? "No related articles found for your text."
                   : "Paste text above to find similar research."
+              }
+              emptyState={
+                hasSearched ? (
+                  <EmptyState
+                    icon={<SearchIcon />}
+                    title="No related research found"
+                    description="No semantically similar articles turned up. Try rephrasing or adding more detail."
+                  />
+                ) : (
+                  <EmptyState
+                    icon={<SparklesIcon />}
+                    title="Find related research"
+                    description="Paste an abstract, snippet, or topic above to discover semantically similar papers."
+                  />
+                )
               }
             />
           )}

--- a/app/routes/semantic-search.tsx
+++ b/app/routes/semantic-search.tsx
@@ -115,8 +115,8 @@ export default function SemanticSearch() {
         </div>
 
         {/* Search Input */}
-        <div className="max-w-7xl mx-auto px-6 pt-6">
-          <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="max-w-7xl mx-auto px-6 pt-4">
+          <form onSubmit={handleSubmit} className="max-w-3xl space-y-3">
             <textarea
               value={text}
               onChange={e => setText(e.target.value)}

--- a/app/routes/semantic-search.tsx
+++ b/app/routes/semantic-search.tsx
@@ -111,7 +111,7 @@ export default function SemanticSearch() {
               onChange={e => setText(e.target.value)}
               placeholder="Paste a snippet, abstract, or topic description to find related research..."
               rows={4}
-              className="w-full rounded-md border border-stone-300 dark:border-slate-600 bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light px-4 py-3 text-sm placeholder:text-stone-500 dark:placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400 resize-y"
+              className="w-full rounded-md border border-stone-300 dark:border-slate-600 bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light px-4 py-3 text-sm placeholder:text-stone-500 dark:placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-accent-dark-fg resize-y"
             />
             <Button
               variant="primary"

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -353,7 +353,7 @@ export default function Settings() {
 
         {/* Content */}
         <div className="max-w-2xl mx-auto px-6 py-8">
-          <h1 className="text-2xl font-semibold text-brand-dark dark:text-brand-light mb-8">
+          <h1 className="text-2xl font-semibold text-brand-dark dark:text-brand-light mb-6">
             Settings
           </h1>
 

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,5 +1,4 @@
 import type { MetaFunction } from "@remix-run/cloudflare";
-import { Link } from "@remix-run/react";
 import { z } from "zod";
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "~/root";
@@ -11,7 +10,9 @@ import {
   ClipboardIcon,
   DownloadIcon,
   ArrowRightIcon,
+  SettingsIcon,
 } from "~/components/layout/Icons";
+import { LoginGate } from "~/components/feedback";
 import { formatPublishedDate } from "~/utils/formatting";
 
 export const meta: MetaFunction = () => {
@@ -357,16 +358,11 @@ export default function Settings() {
           </h1>
 
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to manage your settings.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<SettingsIcon />}
+              title="Manage your account"
+              description="Log in to create API tokens and configure the MCP integration."
+            />
           ) : (
             <section>
               <h2 className="text-lg font-medium text-brand-dark dark:text-brand-light mb-4">

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -261,7 +261,7 @@ function CreateTokenForm({
           value={name}
           onChange={e => setName(e.target.value)}
           placeholder="Token name (optional)"
-          className="flex-1 px-3 py-2 text-sm border border-stone-300 dark:border-slate-600 rounded-md bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light placeholder-stone-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-teal-400"
+          className="flex-1 px-3 py-2 text-sm border border-stone-300 dark:border-slate-600 rounded-md bg-stone-50 dark:bg-slate-800 text-brand-dark dark:text-brand-light placeholder-stone-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-accent dark:focus:ring-accent-dark-fg"
         />
         <Button type="submit" variant="primary" disabled={isCreating}>
           {isCreating ? "Creating..." : "Create Token"}
@@ -469,7 +469,7 @@ export default function Settings() {
               href="/docs/api.html"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-accent dark:bg-teal-400 dark:text-slate-900 rounded-md hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-accent dark:bg-accent-dark rounded-md hover:opacity-90 transition-opacity"
             >
               View API Documentation
               <ArrowRightIcon className="w-4 h-4" />

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -166,7 +166,7 @@ function NewTokenDisplay({
         </button>
       </div>
       <Button variant="outline" onClick={onDismiss} className="text-xs">
-        I&apos;ve copied the token
+        I’ve copied the token
       </Button>
     </div>
   );

--- a/app/routes/unreviewed.tsx
+++ b/app/routes/unreviewed.tsx
@@ -1,11 +1,10 @@
 import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/cloudflare";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { TopBar } from "~/components/layout/TopBar";
 import { HeroHeader } from "~/components/layout/HeroHeader";
 import { ArticleFeed } from "~/components/article/ArticleFeed";
 import { ViewToggle } from "~/components/layout/ViewToggle";
 import { Tabs } from "~/components/ui/Tabs";
-import { Button } from "~/components/ui/Button";
 import { MAIN_TABS } from "~/constants/navigation";
 import { useArticleFeedbackHandlers } from "~/hooks/useArticleFeedbackHandlers";
 import { useUserArticles } from "~/hooks/useUserArticles";
@@ -15,6 +14,8 @@ import {
   fetchArticlesFromApi,
   createPaginationParams,
 } from "~/server/articles.server";
+import { EmptyState, ErrorState, LoginGate } from "~/components/feedback";
+import { CheckCircleIcon } from "~/components/layout/Icons";
 
 export const meta: MetaFunction = () => {
   return [
@@ -56,6 +57,7 @@ export default function Unreviewed() {
     hasMore,
     loadMore,
     setArticles,
+    refetch,
     error: fetchError,
   } = useUserArticles("unreviewed", { initialArticles });
 
@@ -69,9 +71,14 @@ export default function Unreviewed() {
   });
 
   const [viewMode, setViewMode] = useViewPreference();
+  const revalidator = useRevalidator();
 
   const showLoginPrompt = !isAuthenticated;
   const error = loaderError ?? fetchError?.message;
+  const handleRetry = () => {
+    revalidator.revalidate();
+    refetch();
+  };
 
   return (
     <div className="min-h-screen bg-brand-bg dark:bg-brand-bg-dark">
@@ -91,20 +98,13 @@ export default function Unreviewed() {
         {/* Content */}
         <div className="max-w-7xl mx-auto">
           {showLoginPrompt ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-slate-600 dark:text-slate-400 text-lg mb-4">
-                Log in to see your unreviewed articles.
-              </p>
-              <Link to="/auth/login">
-                <Button variant="primary" type="button">
-                  Log In to See Unreviewed Articles
-                </Button>
-              </Link>
-            </div>
+            <LoginGate
+              icon={<CheckCircleIcon />}
+              title="Pick up where you left off"
+              description="Log in to see the research you haven't reviewed yet."
+            />
           ) : error ? (
-            <div className="flex flex-col items-center justify-center py-16 px-4">
-              <p className="text-red-600 dark:text-red-400 text-lg">{error}</p>
-            </div>
+            <ErrorState description={error} onRetry={handleRetry} backTo="/" />
           ) : (
             <>
               <ArticleFeed
@@ -115,6 +115,14 @@ export default function Unreviewed() {
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
                 emptyMessage="No unreviewed articles. You've reviewed everything!"
+                emptyState={
+                  <EmptyState
+                    icon={<CheckCircleIcon />}
+                    title="All caught up"
+                    description="You've reviewed everything. New articles will show up here."
+                    action={{ label: "Browse the feed", to: "/" }}
+                  />
+                }
               />
 
               {hasMore && (

--- a/app/routes/unreviewed.tsx
+++ b/app/routes/unreviewed.tsx
@@ -101,7 +101,7 @@ export default function Unreviewed() {
             <LoginGate
               icon={<CheckCircleIcon />}
               title="Pick up where you left off"
-              description="Log in to see the research you haven't reviewed yet."
+              description="Log in to see the research you haven’t reviewed yet."
             />
           ) : error ? (
             <ErrorState description={error} onRetry={handleRetry} backTo="/" />
@@ -114,12 +114,12 @@ export default function Unreviewed() {
                 onThumbsUp={handleThumbsUp}
                 onThumbsDown={handleThumbsDown}
                 onMarkAsRead={handleMarkAsRead}
-                emptyMessage="No unreviewed articles. You've reviewed everything!"
+                emptyMessage="No unreviewed articles. You’ve reviewed everything!"
                 emptyState={
                   <EmptyState
                     icon={<CheckCircleIcon />}
                     title="All caught up"
-                    description="You've reviewed everything. New articles will show up here."
+                    description="You’ve reviewed everything. New articles will show up here."
                     action={{ label: "Browse the feed", to: "/" }}
                   />
                 }
@@ -131,7 +131,7 @@ export default function Unreviewed() {
 
               {!hasMore && articles.length > 0 && (
                 <div className="text-center py-8 text-slate-600 dark:text-slate-300">
-                  You&apos;ve reached the end of the results.
+                  You’ve reached the end of the results.
                 </div>
               )}
             </>

--- a/app/schemas/article.test.ts
+++ b/app/schemas/article.test.ts
@@ -3,6 +3,7 @@ import {
   ArticleSchema,
   ArticlesResponseSchema,
   parseArticlesResponse,
+  formatAuthorsByline,
 } from "./article";
 
 const validArticle = {
@@ -124,6 +125,34 @@ describe("ArticlesResponseSchema", () => {
     if (result.success) {
       expect(result.data.data).toHaveLength(0);
     }
+  });
+});
+
+describe("formatAuthorsByline", () => {
+  it("returns a single author unchanged", () => {
+    expect(formatAuthorsByline("Jane Doe")).toBe("Jane Doe");
+  });
+
+  it("collapses a comma-separated list to first author + others", () => {
+    expect(
+      formatAuthorsByline("Jane Doe, John Smith, Alex Lee, Sam Park")
+    ).toBe("Jane Doe +3 others");
+  });
+
+  it("handles 'and' separators and uses singular for one extra", () => {
+    expect(formatAuthorsByline("Jane Doe and John Smith")).toBe(
+      "Jane Doe +1 other"
+    );
+  });
+
+  it("respects a higher maxNames before collapsing", () => {
+    expect(formatAuthorsByline("Jane Doe, John Smith, Alex Lee", 2)).toBe(
+      "Jane Doe, John Smith +1 other"
+    );
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(formatAuthorsByline("")).toBe("");
   });
 });
 

--- a/app/schemas/article.ts
+++ b/app/schemas/article.ts
@@ -47,5 +47,24 @@ export function parseArticlesResponse(
   return { success: true, data: result.data };
 }
 
+/**
+ * Format an author list into a compact byline for tight slots.
+ *
+ * Long lists are collapsed to "First Author +N others" so a truncated
+ * byline never falls mid-surname. Lists with `maxNames` or fewer authors
+ * are returned unchanged.
+ */
+export function formatAuthorsByline(authors: string, maxNames = 1): string {
+  if (!authors) return authors;
+  const names = authors
+    .split(/,|\band\b/)
+    .map(name => name.trim())
+    .filter(Boolean);
+  if (names.length <= maxNames) return authors;
+  const shown = names.slice(0, maxNames).join(", ");
+  const remaining = names.length - maxNames;
+  return `${shown} +${remaining} other${remaining === 1 ? "" : "s"}`;
+}
+
 // Re-export formatting utility for convenience
 export { formatPublishedDate } from "~/utils/formatting";

--- a/app/test/settings.test.tsx
+++ b/app/test/settings.test.tsx
@@ -30,9 +30,7 @@ describe("Settings route", () => {
   it("shows login prompt when not authenticated", async () => {
     mockUseAuth.mockReturnValue({ isAuthenticated: false });
     renderSettings();
-    expect(
-      await screen.findByText(/Log in to manage your settings/i)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Manage your account/i)).toBeInTheDocument();
   });
 
   it("shows API Tokens section when authenticated", async () => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,10 @@ export default {
         accent: "#0f766e",
         "accent-hover": "#0d9488",
         "accent-light": "#ccfbf1",
+        "accent-dark": "#0f766e",
+        "accent-dark-hover": "#115e59",
+        "accent-dark-fg": "#14b8a6",
+        "accent-dark-fg-hover": "#2dd4bf",
       },
       fontFamily: {
         serif: ["Georgia", "Times New Roman", "serif"],


### PR DESCRIPTION
## Consolidate the appearance pass (Stages B–E) onto main

The five appearance stages were reviewed as a stacked PR series (#62–#66), each based on the previous branch. Only Stage A (#62) targeted `main`; #63–#66 merged into their parent stage branch, so `main` currently has only Stage A. Because the branches were stacked, `appearance/stage-e-design-system` already holds the full linear A→B→C→D→E. This PR brings the remaining stages (B–E) onto `main`, completing the series.

### Stages included
- **B** — unified restrained dark accent; CVD-safe feedback cue; halation softening.
- **C** — designed empty / error / logged-out states (real retry).
- **D** — typography & iconography polish; source-name truncation priority; `formatAuthorsByline`.
- **E** — design-system polish: unified category-header palette (one restrained tint + left-border across light/dark), with the dark left-border luminance-balanced per hue (`{hue}-800` so no category pops); dark-mode card elevation; semantic-search input measure; ViewToggle active state; titles kept in the sans family.

### Verification
- Full gate green on the tip (`format:check`, `lint` 0 errors, `typecheck`, **vitest 213/213**, `build`).
- Each stage was render-verified offline (light + dark, incl. deuteranopia/protanopia) during its build.
- Merges cleanly onto `main` (merge base = Stage A; no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
