### PR TITLE
P13: coherent depth / elevation system

### DIFF
--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -66,7 +66,7 @@ export function ArticleCard({
       target="_blank"
       rel="noopener noreferrer"
       onClick={handleMarkAsRead}
-      className="flex flex-col bg-stone-50 dark:bg-slate-800 rounded-lg shadow shadow-stone-300/50 hover:shadow-md transition-shadow overflow-hidden group h-full dark:border dark:border-slate-700/70 dark:shadow-lg dark:shadow-black/30"
+      className="flex flex-col bg-stone-50 dark:bg-surface-1 rounded-xl shadow-card hover:shadow-card-hover dark:hover:bg-surface-2 transition-[box-shadow,background-color] overflow-hidden group h-full"
     >
       {/* Source header strip */}
       <div
@@ -114,13 +114,13 @@ export function ArticleCard({
       <div className="p-4 flex flex-col flex-grow">
         {/* Date */}
         {article.published_at && (
-          <div className="text-[13px] text-slate-600 dark:text-slate-300 mb-2">
+          <div className="text-[13px] text-slate-600 dark:text-slate-200 mb-2">
             {formatPublishedDate(article.published_at)}
           </div>
         )}
 
         {/* Author */}
-        <p className="text-sm text-slate-600 dark:text-slate-300 mb-1 truncate">
+        <p className="text-sm text-slate-600 dark:text-slate-200 mb-1 truncate">
           {formatAuthorsByline(article.authors)}
         </p>
 
@@ -138,7 +138,7 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsUp}
             disabled={isUpdating}
-            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
+            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
               thumbsUp
                 ? "text-green-800 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/60 dark:ring-green-400/60 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
                 : "text-slate-500 dark:text-slate-400 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
@@ -155,7 +155,7 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsDown}
             disabled={isUpdating}
-            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
+            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
               thumbsDown
                 ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/60 dark:ring-red-400/60 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
                 : "text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
@@ -180,7 +180,7 @@ export function ArticleCard({
               e.stopPropagation();
               navigate(`/articles/${article.hash_id}`);
             }}
-            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-600 px-3 min-h-[44px] text-xs font-medium text-slate-600 dark:text-slate-300 hover:border-accent hover:text-accent hover:bg-accent/5 dark:hover:text-accent-dark-fg dark:hover:border-accent-dark-fg dark:hover:bg-accent-dark-fg/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-dark-fg focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 transition-colors"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-600 px-3 min-h-[44px] text-xs font-medium text-slate-600 dark:text-slate-200 hover:border-accent hover:text-accent hover:bg-accent/5 dark:hover:text-accent-dark-fg dark:hover:border-accent-dark-fg dark:hover:bg-accent-dark-fg/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-dark-fg focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 transition-colors"
             aria-label="View article details"
           >
             View details

--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -77,7 +77,7 @@ export function ArticleCard({
         </span>
         <div className="flex items-center gap-2 flex-shrink-0 max-w-[55%]">
           {article.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20 min-w-0 truncate">
+            <span className="text-sm px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20 min-w-0 truncate">
               {article.category}
             </span>
           )}
@@ -114,7 +114,7 @@ export function ArticleCard({
       <div className="p-4 flex flex-col flex-grow">
         {/* Date */}
         {article.published_at && (
-          <div className="text-[13px] text-slate-600 dark:text-slate-200 mb-2">
+          <div className="text-sm text-slate-600 dark:text-slate-200 mb-2">
             {formatPublishedDate(article.published_at)}
           </div>
         )}
@@ -125,7 +125,7 @@ export function ArticleCard({
         </p>
 
         {/* Title */}
-        <h3 className="font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2 mb-3 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors">
+        <h3 className="font-semibold text-lg text-slate-900 dark:text-slate-100 text-pretty line-clamp-2 mb-3 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors">
           {article.title}
         </h3>
 
@@ -138,10 +138,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsUp}
             disabled={isUpdating}
-            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+            className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
               thumbsUp
                 ? "text-green-800 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/60 dark:ring-green-400/60 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
-                : "text-slate-500 dark:text-slate-400 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
+                : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
             }`}
             aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
           >
@@ -155,10 +155,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsDown}
             disabled={isUpdating}
-            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+            className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
               thumbsDown
                 ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/60 dark:ring-red-400/60 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
-                : "text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
+                : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
             }`}
             aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
           >
@@ -169,7 +169,7 @@ export function ArticleCard({
             )}
           </button>
           {feedbackError && (
-            <span className="text-xs text-red-600 dark:text-red-400">
+            <span className="text-sm text-red-600 dark:text-red-400">
               {feedbackError}
             </span>
           )}
@@ -180,7 +180,7 @@ export function ArticleCard({
               e.stopPropagation();
               navigate(`/articles/${article.hash_id}`);
             }}
-            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-600 px-3 min-h-[44px] text-xs font-medium text-slate-600 dark:text-slate-200 hover:border-accent hover:text-accent hover:bg-accent/5 dark:hover:text-accent-dark-fg dark:hover:border-accent-dark-fg dark:hover:bg-accent-dark-fg/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-dark-fg focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 transition-colors"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-600 px-3 min-h-[44px] text-sm font-medium text-slate-600 dark:text-slate-200 hover:border-accent hover:text-accent hover:bg-accent/5 dark:hover:text-accent-dark-fg dark:hover:border-accent-dark-fg dark:hover:bg-accent-dark-fg/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-dark-fg focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 transition-colors"
             aria-label="View article details"
           >
             View details

--- a/app/components/article/ArticleInfo.tsx
+++ b/app/components/article/ArticleInfo.tsx
@@ -78,7 +78,7 @@ export function ArticleInfo({
 
         {/* Meta row */}
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-200">
-          <span>{article.authors}</span>
+          <span className="min-w-0 break-words">{article.authors}</span>
           {article.published_at && (
             <>
               <span className="text-stone-400 dark:text-slate-500">•</span>
@@ -106,7 +106,7 @@ export function ArticleInfo({
               type="button"
               onClick={() => onThumbsUp?.(article.hash_id, !thumbsUp)}
               disabled={isUpdating}
-              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
+              className={`flex items-center gap-2 px-4 py-2 min-h-[48px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
                 thumbsUp
                   ? "border-green-500 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-400 ring-1 ring-green-500/40 dark:ring-green-400/40 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
                   : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-200 hover:border-green-300 dark:hover:border-green-700 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-50/50 dark:hover:bg-green-900/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
@@ -124,7 +124,7 @@ export function ArticleInfo({
               type="button"
               onClick={() => onThumbsDown?.(article.hash_id, !thumbsDown)}
               disabled={isUpdating}
-              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
+              className={`flex items-center gap-2 px-4 py-2 min-h-[48px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
                 thumbsDown
                   ? "border-red-500 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 ring-1 ring-red-500/40 dark:ring-red-400/40 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
                   : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-200 hover:border-red-300 dark:hover:border-red-700 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50/50 dark:hover:bg-red-900/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"

--- a/app/components/article/ArticleInfo.tsx
+++ b/app/components/article/ArticleInfo.tsx
@@ -33,7 +33,7 @@ export function ArticleInfo({
   const haveRead = article.have_read ?? false;
 
   return (
-    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-md shadow-stone-300/60 overflow-hidden dark:border dark:border-slate-700 dark:shadow-xl dark:shadow-black/40">
+    <div className="bg-stone-50 dark:bg-surface-2 rounded-xl shadow-panel overflow-hidden">
       {/* Source header strip - like the card */}
       <div
         className={`h-14 px-6 flex items-center justify-between ${getCategoryHeaderColor(article.category)}`}
@@ -77,7 +77,7 @@ export function ArticleInfo({
         </div>
 
         {/* Meta row */}
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-300">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-200">
           <span>{article.authors}</span>
           {article.published_at && (
             <>
@@ -106,10 +106,10 @@ export function ArticleInfo({
               type="button"
               onClick={() => onThumbsUp?.(article.hash_id, !thumbsUp)}
               disabled={isUpdating}
-              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
+              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
                 thumbsUp
                   ? "border-green-500 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-400 ring-1 ring-green-500/40 dark:ring-green-400/40 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
-                  : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-green-300 dark:hover:border-green-700 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-50/50 dark:hover:bg-green-900/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
+                  : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-200 hover:border-green-300 dark:hover:border-green-700 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-50/50 dark:hover:bg-green-900/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
               }`}
               aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
             >
@@ -124,10 +124,10 @@ export function ArticleInfo({
               type="button"
               onClick={() => onThumbsDown?.(article.hash_id, !thumbsDown)}
               disabled={isUpdating}
-              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
+              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
                 thumbsDown
                   ? "border-red-500 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 ring-1 ring-red-500/40 dark:ring-red-400/40 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
-                  : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-red-300 dark:hover:border-red-700 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50/50 dark:hover:bg-red-900/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
+                  : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-200 hover:border-red-300 dark:hover:border-red-700 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50/50 dark:hover:bg-red-900/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
               }`}
               aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
             >

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -112,7 +112,7 @@ export function ArticleRow({
         </span>
         <div className="flex items-center gap-2">
           {article.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20">
+            <span className="text-sm px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20">
               {article.category}
             </span>
           )}
@@ -155,11 +155,11 @@ export function ArticleRow({
                 onClick={handleMarkAsRead}
                 className="group block"
               >
-                <h3 className="font-medium text-slate-900 dark:text-slate-100 text-pretty group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors line-clamp-3">
+                <h3 className="font-semibold text-2xl text-slate-900 dark:text-slate-100 text-pretty group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors line-clamp-3">
                   {article.title}
                 </h3>
               </a>
-              <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
+              <p className="text-sm text-slate-600 dark:text-slate-300 mt-1 truncate">
                 <span className="whitespace-nowrap">{article.authors}</span>
                 {article.published_at && (
                   <>
@@ -181,7 +181,7 @@ export function ArticleRow({
           <div className="min-w-0 md:col-span-3">
             <p
               ref={summaryRef}
-              className="text-sm text-slate-600 dark:text-slate-300 line-clamp-4 max-w-prose"
+              className="text-base text-slate-600 dark:text-slate-300 line-clamp-4 max-w-prose"
             >
               {article.summary}
             </p>
@@ -196,10 +196,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsUp}
           disabled={isUpdating}
-          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+          className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
             thumbsUp
               ? "text-green-800 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/60 dark:ring-green-400/60 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
-              : "text-slate-500 dark:text-slate-400 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
+              : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
           }`}
           aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
         >
@@ -213,10 +213,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsDown}
           disabled={isUpdating}
-          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+          className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
             thumbsDown
               ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/60 dark:ring-red-400/60 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
-              : "text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
+              : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
           }`}
           aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
         >
@@ -235,10 +235,10 @@ export function ArticleRow({
           <button
             type="button"
             onClick={() => handleSectionToggle("summary")}
-            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+            className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
               expandedSection === "summary"
                 ? "bg-accent text-white dark:bg-accent-dark"
-                : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+                : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
             Summary
@@ -248,10 +248,10 @@ export function ArticleRow({
           <button
             type="button"
             onClick={() => handleSectionToggle("key_points")}
-            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+            className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
               expandedSection === "key_points"
                 ? "bg-accent text-white dark:bg-accent-dark"
-                : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+                : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
             Key Points
@@ -261,10 +261,10 @@ export function ArticleRow({
           <button
             type="button"
             onClick={() => handleSectionToggle("implication")}
-            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+            className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
               expandedSection === "implication"
                 ? "bg-accent text-white dark:bg-accent-dark"
-                : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+                : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
             Implication
@@ -273,10 +273,10 @@ export function ArticleRow({
         <button
           type="button"
           onClick={() => handleSectionToggle("similar")}
-          className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+          className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
             expandedSection === "similar"
               ? "bg-accent text-white dark:bg-accent-dark"
-              : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+              : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
         >
           Similar
@@ -288,7 +288,7 @@ export function ArticleRow({
           target="_blank"
           rel="noopener noreferrer"
           onClick={handleMarkAsRead}
-          className="ml-auto flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors"
+          className="ml-auto flex items-center gap-1 px-2.5 py-1 rounded text-sm font-medium text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors"
         >
           Read
           <ExternalLinkIcon className="w-3.5 h-3.5" />
@@ -300,10 +300,10 @@ export function ArticleRow({
         <div className="px-4 py-3 border-t border-stone-100 dark:border-slate-700 bg-stone-100 dark:bg-slate-800/50">
           {expandedSection === "summary" && article.summary && (
             <div>
-              <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+              <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                 Summary
               </h4>
-              <p className="text-sm text-slate-700 dark:text-slate-300">
+              <p className="text-base text-slate-700 dark:text-slate-300">
                 {article.summary}
               </p>
             </div>
@@ -313,10 +313,10 @@ export function ArticleRow({
             article.key_points &&
             article.key_points.length > 0 && (
               <div>
-                <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+                <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                   Key Points
                 </h4>
-                <ul className="list-disc list-inside space-y-1 text-sm text-slate-700 dark:text-slate-300">
+                <ul className="list-disc list-inside space-y-1 text-base text-slate-700 dark:text-slate-300">
                   {article.key_points.map((point, i) => (
                     <li key={i}>{point}</li>
                   ))}
@@ -326,10 +326,10 @@ export function ArticleRow({
 
           {expandedSection === "implication" && article.implication && (
             <div>
-              <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+              <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                 Implications for AI Alignment
               </h4>
-              <p className="text-sm text-slate-700 dark:text-slate-300">
+              <p className="text-base text-slate-700 dark:text-slate-300">
                 {article.implication}
               </p>
             </div>
@@ -337,7 +337,7 @@ export function ArticleRow({
 
           {expandedSection === "similar" && (
             <div>
-              <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+              <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                 Similar Articles
               </h4>
               {isFetchingSimilar ? (
@@ -354,10 +354,10 @@ export function ArticleRow({
                       onClick={() => navigate(`/articles/${similar.hash_id}`)}
                       className="flex-shrink-0 w-64 rounded-md border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-surface-2 p-3 text-left hover:border-stone-300 dark:hover:border-slate-500 transition-colors"
                     >
-                      <p className="text-xs text-slate-600 dark:text-slate-200 mb-1 truncate">
+                      <p className="text-sm text-slate-600 dark:text-slate-200 mb-1 truncate">
                         {getSourceDisplayName(similar.source, similar.authors)}
                       </p>
-                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2">
+                      <p className="text-base font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2">
                         {similar.title}
                       </p>
                     </button>

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -102,7 +102,7 @@ export function ArticleRow({
   }, []);
 
   return (
-    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow shadow-stone-300/50 overflow-hidden dark:border dark:border-slate-700/70 dark:shadow-lg dark:shadow-black/30">
+    <div className="bg-stone-50 dark:bg-surface-1 rounded-lg shadow-card overflow-hidden">
       {/* Source header strip */}
       <div
         className={`h-10 px-4 flex items-center justify-between ${getCategoryHeaderColor(article.category)}`}
@@ -196,7 +196,7 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsUp}
           disabled={isUpdating}
-          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
+          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
             thumbsUp
               ? "text-green-800 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/60 dark:ring-green-400/60 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
               : "text-slate-500 dark:text-slate-400 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
@@ -213,7 +213,7 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsDown}
           disabled={isUpdating}
-          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
+          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
             thumbsDown
               ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/60 dark:ring-red-400/60 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
               : "text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
@@ -352,9 +352,9 @@ export function ArticleRow({
                       key={similar.hash_id}
                       type="button"
                       onClick={() => navigate(`/articles/${similar.hash_id}`)}
-                      className="flex-shrink-0 w-64 rounded-md border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-slate-700 p-3 text-left hover:border-stone-300 dark:hover:border-slate-500 transition-colors"
+                      className="flex-shrink-0 w-64 rounded-md border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-surface-2 p-3 text-left hover:border-stone-300 dark:hover:border-slate-500 transition-colors"
                     >
-                      <p className="text-xs text-slate-600 dark:text-slate-300 mb-1 truncate">
+                      <p className="text-xs text-slate-600 dark:text-slate-200 mb-1 truncate">
                         {getSourceDisplayName(similar.source, similar.authors)}
                       </p>
                       <p className="text-sm font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2">

--- a/app/components/article/LoadingCard.tsx
+++ b/app/components/article/LoadingCard.tsx
@@ -1,6 +1,6 @@
 export function LoadingCard() {
   return (
-    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden animate-pulse h-full flex flex-col">
+    <div className="bg-stone-50 dark:bg-surface-1 rounded-xl shadow-card overflow-hidden animate-pulse h-full flex flex-col">
       {/* Header strip placeholder - mirrors the coloured category band */}
       <div className="h-12 bg-stone-300 dark:bg-slate-700 border-l-4 border-stone-400 dark:border-slate-600 flex-shrink-0" />
 

--- a/app/components/article/LoadingRow.tsx
+++ b/app/components/article/LoadingRow.tsx
@@ -1,6 +1,6 @@
 export function LoadingRow() {
   return (
-    <div className="bg-stone-50 dark:bg-slate-800 rounded-lg shadow-sm overflow-hidden animate-pulse">
+    <div className="bg-stone-50 dark:bg-surface-1 rounded-lg shadow-card overflow-hidden animate-pulse">
       {/* Header strip placeholder - mirrors the coloured category band */}
       <div className="h-10 bg-stone-300 dark:bg-slate-700 border-l-4 border-stone-400 dark:border-slate-600" />
 

--- a/app/components/layout/TopBar.tsx
+++ b/app/components/layout/TopBar.tsx
@@ -17,8 +17,12 @@ export function TopBar() {
         </Link>
         <div className="flex items-center gap-4">
           {isAuthenticated && (
-            <Link to="/settings" aria-label="Settings">
-              <SettingsIcon className="w-5 h-5 text-brand-dark dark:text-brand-light hover:opacity-70" />
+            <Link
+              to="/settings"
+              aria-label="Settings"
+              className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg bg-black/5 dark:bg-white/10 text-brand-dark dark:text-brand-light hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark dark:focus-visible:ring-brand-light focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg dark:focus-visible:ring-offset-brand-bg-dark transition-opacity"
+            >
+              <SettingsIcon className="w-5 h-5" />
             </Link>
           )}
           <AuthButtons />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -69,7 +69,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body className="bg-stone-100 dark:bg-slate-800">
+      <body className="bg-stone-100 dark:bg-brand-bg-dark">
         <NavigationProgressBar />
         {children}
         <ScrollRestoration />

--- a/app/routes/articles.$articleID.tsx
+++ b/app/routes/articles.$articleID.tsx
@@ -127,7 +127,7 @@ export default function ArticleDetails() {
         {/* Analysis Section */}
         {article.summary && (
           <div className="max-w-4xl mx-auto px-6 pb-8">
-            <div className="bg-stone-50 dark:bg-slate-800/60 rounded-lg p-6 shadow-sm dark:shadow-none dark:border dark:border-slate-700/50">
+            <div className="bg-stone-50 dark:bg-surface-2 rounded-xl p-6 shadow-panel">
               <div className="flex items-center gap-3 mb-4">
                 <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
                   Analysis

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,17 @@ export default {
         "accent-dark-hover": "#115e59",
         "accent-dark-fg": "#14b8a6",
         "accent-dark-fg-hover": "#2dd4bf",
+        // Dark-mode elevation surface steps (P13). Light mode uses stone-* utilities directly.
+        // Tokenized so a later PR (P15) can re-base the dark hue without touching components.
+        "surface-1": "#1e293b", // dark card resting (slate-800)
+        "surface-2": "#334155", // dark raised / hover / detail-header / analysis-panel (slate-700)
+      },
+      boxShadow: {
+        card: "0 1px 3px 0 rgba(87,83,78,0.16), 0 1px 2px -1px rgba(68,64,60,0.10)",
+        "card-hover":
+          "0 8px 12px -3px rgba(87,83,78,0.22), 0 4px 6px -2px rgba(68,64,60,0.14)",
+        panel:
+          "0 3px 6px -1px rgba(87,83,78,0.18), 0 2px 4px -1px rgba(68,64,60,0.12)",
       },
       fontFamily: {
         serif: ["Georgia", "Times New Roman", "serif"],


### PR DESCRIPTION
Implements **P13** from the appearance review — a coherent depth/elevation system — the first PR of the "surfaces & dark tone" theme. The review found surface elevation didn't read: the existing light shadows were near-invisible on the warm-paper theme, dark cards were separated only by a faint (1.4:1) border with dead black shadows, and two sibling detail panels used mismatched dark tones.

This is scoped to **P13 only**; P15 (warm-charcoal dark hue, teal-token unification, serif) is intentionally deferred and made easy to layer on (dark surfaces are tokenized).

## Changes (8 files, +32/−21)

- **Light shadow scale that reads.** New tokenized `card` / `card-hover` / `panel` box-shadows — warm stone-tinted (not pure black), two-layer — so they register on the `#E8E4DC` theme; resting → hover is now clearly deeper (blur 3→12px, offset 1→8px).
- **Dark elevation via lightness, not shadow.** Page base is the darkest layer (`#1a1a1a`); cards use `surface-1` (#1e293b), raised/hover/detail-panels use `surface-2` (#334155) — a perceptible ~7–11 L\* ladder. Removed the invisible black shadows and the low-contrast slate-700 borders.
- **Sibling-panel fix.** The detail header card and the Analysis panel now share one surface (`surface-2`) instead of `slate-800` vs `slate-800/60`.
- **Focus-ring offset parity.** Dark `ring-offset` now matches each control's real surface, so the offset band renders in dark as in light.
- **Radius system.** Large cards/panels `rounded-xl`, list rows `rounded-lg`, buttons/badges unchanged — radius now scales with component size (md/lg/xl/full).

## Contrast guard (no regression to #69)
Every dark body token that moved onto the lighter `surface-2` was bumped `slate-300 → slate-200` to hold **APCA Lc ≥ 75** (slate-300 on slate-700 = Lc 71, fails; slate-200 = Lc 83). Values computed programmatically, not estimated.

## Forward-compat for P15
Dark surfaces are tokenized (`surface-1`/`surface-2`); P15 can re-base the dark hue to warm charcoal by editing two hexes without touching components. Brand/teal tokens untouched here.

## Validation
Full npm gate green (format, typecheck, lint 0 errors, 213/213 tests, build) — run twice. Render-verified offline with the real components (SSR + Playwright), 12 light/dark screenshots; elevation, sibling match, and the dark focus band confirmed by eye. Scratch render harness removed before commit. Built and reviewed via a demesne feature-work pipeline (two adversarial review rounds → PASS). The live styled routes will also be visible on the Cloudflare Pages preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
