### PR TITLE
P11 + P12: type hierarchy & resting affordance (+ detail author-overflow fix)

### DIFF
--- a/app/components/article/ArticleCard.tsx
+++ b/app/components/article/ArticleCard.tsx
@@ -77,7 +77,7 @@ export function ArticleCard({
         </span>
         <div className="flex items-center gap-2 flex-shrink-0 max-w-[55%]">
           {article.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20 min-w-0 truncate">
+            <span className="text-sm px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20 min-w-0 truncate">
               {article.category}
             </span>
           )}
@@ -114,7 +114,7 @@ export function ArticleCard({
       <div className="p-4 flex flex-col flex-grow">
         {/* Date */}
         {article.published_at && (
-          <div className="text-[13px] text-slate-600 dark:text-slate-200 mb-2">
+          <div className="text-sm text-slate-600 dark:text-slate-200 mb-2">
             {formatPublishedDate(article.published_at)}
           </div>
         )}
@@ -125,7 +125,7 @@ export function ArticleCard({
         </p>
 
         {/* Title */}
-        <h3 className="font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2 mb-3 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors">
+        <h3 className="font-semibold text-lg text-slate-900 dark:text-slate-100 text-pretty line-clamp-2 mb-3 group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors">
           {article.title}
         </h3>
 
@@ -138,10 +138,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsUp}
             disabled={isUpdating}
-            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+            className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
               thumbsUp
                 ? "text-green-800 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/60 dark:ring-green-400/60 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
-                : "text-slate-500 dark:text-slate-400 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
+                : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
             }`}
             aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
           >
@@ -155,10 +155,10 @@ export function ArticleCard({
             type="button"
             onClick={handleThumbsDown}
             disabled={isUpdating}
-            className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+            className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
               thumbsDown
                 ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/60 dark:ring-red-400/60 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
-                : "text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
+                : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
             }`}
             aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
           >
@@ -169,7 +169,7 @@ export function ArticleCard({
             )}
           </button>
           {feedbackError && (
-            <span className="text-xs text-red-600 dark:text-red-400">
+            <span className="text-sm text-red-600 dark:text-red-400">
               {feedbackError}
             </span>
           )}
@@ -180,7 +180,7 @@ export function ArticleCard({
               e.stopPropagation();
               navigate(`/articles/${article.hash_id}`);
             }}
-            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-600 px-3 min-h-[44px] text-xs font-medium text-slate-600 dark:text-slate-200 hover:border-accent hover:text-accent hover:bg-accent/5 dark:hover:text-accent-dark-fg dark:hover:border-accent-dark-fg dark:hover:bg-accent-dark-fg/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-dark-fg focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 transition-colors"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-stone-200 dark:border-slate-600 px-3 min-h-[44px] text-sm font-medium text-slate-600 dark:text-slate-200 hover:border-accent hover:text-accent hover:bg-accent/5 dark:hover:text-accent-dark-fg dark:hover:border-accent-dark-fg dark:hover:bg-accent-dark-fg/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:focus-visible:ring-accent-dark-fg focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 transition-colors"
             aria-label="View article details"
           >
             View details

--- a/app/components/article/ArticleInfo.tsx
+++ b/app/components/article/ArticleInfo.tsx
@@ -78,7 +78,7 @@ export function ArticleInfo({
 
         {/* Meta row */}
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-slate-600 dark:text-slate-200">
-          <span>{article.authors}</span>
+          <span className="min-w-0 break-words">{article.authors}</span>
           {article.published_at && (
             <>
               <span className="text-stone-400 dark:text-slate-500">•</span>
@@ -106,7 +106,7 @@ export function ArticleInfo({
               type="button"
               onClick={() => onThumbsUp?.(article.hash_id, !thumbsUp)}
               disabled={isUpdating}
-              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
+              className={`flex items-center gap-2 px-4 py-2 min-h-[48px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
                 thumbsUp
                   ? "border-green-500 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-400 ring-1 ring-green-500/40 dark:ring-green-400/40 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
                   : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-200 hover:border-green-300 dark:hover:border-green-700 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-50/50 dark:hover:bg-green-900/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
@@ -124,7 +124,7 @@ export function ArticleInfo({
               type="button"
               onClick={() => onThumbsDown?.(article.hash_id, !thumbsDown)}
               disabled={isUpdating}
-              className={`flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
+              className={`flex items-center gap-2 px-4 py-2 min-h-[48px] rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-2 ${
                 thumbsDown
                   ? "border-red-500 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 ring-1 ring-red-500/40 dark:ring-red-400/40 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
                   : "border-stone-200 dark:border-slate-600 text-slate-500 dark:text-slate-200 hover:border-red-300 dark:hover:border-red-700 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50/50 dark:hover:bg-red-900/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"

--- a/app/components/article/ArticleRow.tsx
+++ b/app/components/article/ArticleRow.tsx
@@ -112,7 +112,7 @@ export function ArticleRow({
         </span>
         <div className="flex items-center gap-2">
           {article.category && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20">
+            <span className="text-sm px-1.5 py-0.5 rounded bg-black/10 dark:bg-black/20">
               {article.category}
             </span>
           )}
@@ -155,11 +155,11 @@ export function ArticleRow({
                 onClick={handleMarkAsRead}
                 className="group block"
               >
-                <h3 className="font-medium text-slate-900 dark:text-slate-100 text-pretty group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors line-clamp-3">
+                <h3 className="font-semibold text-2xl text-slate-900 dark:text-slate-100 text-pretty group-hover:text-brand-dark dark:group-hover:text-brand-light transition-colors line-clamp-3">
                   {article.title}
                 </h3>
               </a>
-              <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">
+              <p className="text-sm text-slate-600 dark:text-slate-300 mt-1 truncate">
                 <span className="whitespace-nowrap">{article.authors}</span>
                 {article.published_at && (
                   <>
@@ -181,7 +181,7 @@ export function ArticleRow({
           <div className="min-w-0 md:col-span-3">
             <p
               ref={summaryRef}
-              className="text-sm text-slate-600 dark:text-slate-300 line-clamp-4 max-w-prose"
+              className="text-base text-slate-600 dark:text-slate-300 line-clamp-4 max-w-prose"
             >
               {article.summary}
             </p>
@@ -196,10 +196,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsUp}
           disabled={isUpdating}
-          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+          className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
             thumbsUp
               ? "text-green-800 dark:text-green-400 bg-green-600/15 dark:bg-green-500/20 ring-1 ring-green-600/60 dark:ring-green-400/60 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
-              : "text-slate-500 dark:text-slate-400 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
+              : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-green-600 dark:hover:text-green-400 hover:bg-green-600/10 dark:hover:bg-green-500/10 focus-visible:ring-green-600 dark:focus-visible:ring-green-400"
           }`}
           aria-label={thumbsUp ? "Remove thumbs up" : "Thumbs up"}
         >
@@ -213,10 +213,10 @@ export function ArticleRow({
           type="button"
           onClick={handleThumbsDown}
           disabled={isUpdating}
-          className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
+          className={`inline-flex items-center justify-center min-w-[48px] min-h-[48px] rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-surface-1 ${
             thumbsDown
               ? "text-red-600 dark:text-red-400 bg-red-600/15 dark:bg-red-500/20 ring-1 ring-red-600/60 dark:ring-red-400/60 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
-              : "text-slate-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
+              : "text-slate-500 dark:text-slate-400 bg-slate-500/10 dark:bg-slate-100/10 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-600/10 dark:hover:bg-red-500/10 focus-visible:ring-red-600 dark:focus-visible:ring-red-400"
           }`}
           aria-label={thumbsDown ? "Remove thumbs down" : "Thumbs down"}
         >
@@ -235,10 +235,10 @@ export function ArticleRow({
           <button
             type="button"
             onClick={() => handleSectionToggle("summary")}
-            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+            className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
               expandedSection === "summary"
                 ? "bg-accent text-white dark:bg-accent-dark"
-                : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+                : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
             Summary
@@ -248,10 +248,10 @@ export function ArticleRow({
           <button
             type="button"
             onClick={() => handleSectionToggle("key_points")}
-            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+            className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
               expandedSection === "key_points"
                 ? "bg-accent text-white dark:bg-accent-dark"
-                : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+                : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
             Key Points
@@ -261,10 +261,10 @@ export function ArticleRow({
           <button
             type="button"
             onClick={() => handleSectionToggle("implication")}
-            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+            className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
               expandedSection === "implication"
                 ? "bg-accent text-white dark:bg-accent-dark"
-                : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+                : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
             }`}
           >
             Implication
@@ -273,10 +273,10 @@ export function ArticleRow({
         <button
           type="button"
           onClick={() => handleSectionToggle("similar")}
-          className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+          className={`px-2.5 py-1 rounded text-sm font-medium transition-colors ${
             expandedSection === "similar"
               ? "bg-accent text-white dark:bg-accent-dark"
-              : "text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700"
+              : "text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700"
           }`}
         >
           Similar
@@ -288,7 +288,7 @@ export function ArticleRow({
           target="_blank"
           rel="noopener noreferrer"
           onClick={handleMarkAsRead}
-          className="ml-auto flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium text-slate-600 dark:text-slate-300 hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors"
+          className="ml-auto flex items-center gap-1 px-2.5 py-1 rounded text-sm font-medium text-slate-600 dark:text-slate-300 ring-1 ring-inset ring-stone-300 dark:ring-slate-600 hover:bg-stone-100 dark:hover:bg-slate-700 transition-colors"
         >
           Read
           <ExternalLinkIcon className="w-3.5 h-3.5" />
@@ -300,10 +300,10 @@ export function ArticleRow({
         <div className="px-4 py-3 border-t border-stone-100 dark:border-slate-700 bg-stone-100 dark:bg-slate-800/50">
           {expandedSection === "summary" && article.summary && (
             <div>
-              <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+              <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                 Summary
               </h4>
-              <p className="text-sm text-slate-700 dark:text-slate-300">
+              <p className="text-base text-slate-700 dark:text-slate-300">
                 {article.summary}
               </p>
             </div>
@@ -313,10 +313,10 @@ export function ArticleRow({
             article.key_points &&
             article.key_points.length > 0 && (
               <div>
-                <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+                <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                   Key Points
                 </h4>
-                <ul className="list-disc list-inside space-y-1 text-sm text-slate-700 dark:text-slate-300">
+                <ul className="list-disc list-inside space-y-1 text-base text-slate-700 dark:text-slate-300">
                   {article.key_points.map((point, i) => (
                     <li key={i}>{point}</li>
                   ))}
@@ -326,10 +326,10 @@ export function ArticleRow({
 
           {expandedSection === "implication" && article.implication && (
             <div>
-              <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+              <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                 Implications for AI Alignment
               </h4>
-              <p className="text-sm text-slate-700 dark:text-slate-300">
+              <p className="text-base text-slate-700 dark:text-slate-300">
                 {article.implication}
               </p>
             </div>
@@ -337,7 +337,7 @@ export function ArticleRow({
 
           {expandedSection === "similar" && (
             <div>
-              <h4 className="text-xs font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
+              <h4 className="text-sm font-medium text-slate-600 dark:text-slate-300 uppercase tracking-wide mb-2">
                 Similar Articles
               </h4>
               {isFetchingSimilar ? (
@@ -354,10 +354,10 @@ export function ArticleRow({
                       onClick={() => navigate(`/articles/${similar.hash_id}`)}
                       className="flex-shrink-0 w-64 rounded-md border border-stone-200 dark:border-slate-600 bg-stone-50 dark:bg-surface-2 p-3 text-left hover:border-stone-300 dark:hover:border-slate-500 transition-colors"
                     >
-                      <p className="text-xs text-slate-600 dark:text-slate-200 mb-1 truncate">
+                      <p className="text-sm text-slate-600 dark:text-slate-200 mb-1 truncate">
                         {getSourceDisplayName(similar.source, similar.authors)}
                       </p>
-                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2">
+                      <p className="text-base font-medium text-slate-900 dark:text-slate-100 text-pretty line-clamp-2">
                         {similar.title}
                       </p>
                     </button>

--- a/app/components/layout/TopBar.tsx
+++ b/app/components/layout/TopBar.tsx
@@ -17,8 +17,12 @@ export function TopBar() {
         </Link>
         <div className="flex items-center gap-4">
           {isAuthenticated && (
-            <Link to="/settings" aria-label="Settings">
-              <SettingsIcon className="w-5 h-5 text-brand-dark dark:text-brand-light hover:opacity-70" />
+            <Link
+              to="/settings"
+              aria-label="Settings"
+              className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg bg-black/5 dark:bg-white/10 text-brand-dark dark:text-brand-light hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark dark:focus-visible:ring-brand-light focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg dark:focus-visible:ring-offset-brand-bg-dark transition-opacity"
+            >
+              <SettingsIcon className="w-5 h-5" />
             </Link>
           )}
           <AuthButtons />


### PR DESCRIPTION
Second PR of the "type & interaction" theme from the appearance review — implements **P11** (typography / list-view hierarchy) and **P12** (resting-state affordance), plus a user-reported detail-view author-row overflow fix.

**Stacked on #70 (P13 depth/elevation)** — base is `improvement/depth-elevation`, so this diff is just the P11/P12 work (4 files). Retarget to `main` once #70 merges.

## Changes (4 files, +44/−40)

**P11 — restore list-view hierarchy & lift sub-floor type**
- Row excerpt → `text-base` (16px); row **title → `text-2xl` semibold** (24px) = exactly the 1.5× heading-to-body ratio the review asked for (was ~1.0×).
- Card title → `text-lg` semibold; card date `text-[13px]` → `text-sm`; captions/badges/toggle-tabs/eyebrows lifted onto a coherent 14/16/18/24 ramp. Body ≥16px / secondary ≥14px floors hold at every breakpoint.

**P12 — make controls look interactive at rest**
- Icon thumbs get a persistent `bg-slate-500/10 dark:bg-slate-100/10` resting tint + **48×48** hit-area (no more hover-only affordance — matters on touch).
- Row toggle tabs (Summary / Key Points / Implication / Similar) and the Read link get a resting inset ring; solid fill stays reserved for the active tab.
- Header settings gear gets a tinted 44px hit-area + focus ring.
- Selected (green/red), hover, and #70's focus-ring states preserved.

**Bug — detail author row overflow (reported)**
- `ArticleInfo` authors span → `min-w-0 break-words` (fixes the flex `min-width:auto` overflow on long unbroken tokens). `ArticleRow` author `<p>` → `truncate` (with the intentional `whitespace-nowrap` preserved). Verified with a ~2000-char unbroken fixture token: it now wraps inside the card, `scrollWidth == clientWidth`, zero horizontal overflow.

## Validation
Full npm gate green (format, typecheck, lint 0 errors, 213/213 tests, build). Render-verified offline in both light/dark at 1280px. Independent review: **16/16 PASS**, no P13 or P1–P3 contrast regressions, no out-of-scope edits.

One non-blocking follow-up noted: the inactive-tab resting ring reuses the app's existing affordance-border token (~1.4–1.9:1), below the 3:1 non-text target — better fixed app-wide than as a one-off here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
